### PR TITLE
Re-enable swagger deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,13 +91,13 @@ deploy:
       tags: true
       condition: $TRAVIS_TAG =~ ^ams-v 
   
-  #- provider: script
-  #  script: "curl -g --ftp-create-dirs -T target/swagger/swagger.json -u $SWAGGER_FTP_USERNAME:$SWAGGER_FTP_PASSWORD $SWAGGER_FTP_URL/$RELEASE_VERSION/" 
-  #  skip_cleanup: true
-  #  on:
+  - provider: script
+    script: "curl -g --ftp-create-dirs -T target/swagger/swagger.json -u $SWAGGER_FTP_USERNAME:$SWAGGER_FTP_PASSWORD $SWAGGER_FTP_URL/$RELEASE_VERSION/"
+    skip_cleanup: true
+    on:
       #deploy to website if it is a release tagged
-  #    tags: true
-  #    condition: $TRAVIS_TAG =~ ^ams-v 
+      tags: true
+      condition: $TRAVIS_TAG =~ ^ams-v
   
   - provider: releases
     api_key: $GITHUB_OAUTH_TOKEN


### PR DESCRIPTION
This PR re-enables swagger deploy. Travis secure variables are updated.

