### PR TITLE
Extracting constants from duplicated Strings with length >= 5

### DIFF
--- a/src/main/java/com/antstreaming/rtsp/PacketSenderRunnable.java
+++ b/src/main/java/com/antstreaming/rtsp/PacketSenderRunnable.java
@@ -41,6 +41,8 @@ import org.slf4j.LoggerFactory;
 
 public class PacketSenderRunnable implements Runnable {
 
+	private static final String ERROR_CODE = " error code:";
+	private static final String DESCRIPTION = " description: ";
 
 	AVPacket pkt = new AVPacket();
 
@@ -311,8 +313,8 @@ public class PacketSenderRunnable implements Runnable {
 		if (ret < 0) {
 			byte[] data = new byte[4096];
 			avutil.av_strerror(ret, data, data.length);
-			logger.warn("could not open input " + rtmpUrl + " error code:" + ret
-					+ " description: " + new String(data));
+			logger.warn("could not open input " + rtmpUrl + ERROR_CODE + ret
+					+ DESCRIPTION + new String(data));
 			return null;
 		}
 
@@ -324,8 +326,8 @@ public class PacketSenderRunnable implements Runnable {
 			if (ret < 0) {
 				byte[] data = new byte[4096];
 				avutil.av_strerror(ret, data, data.length);
-				logger.warn("could not find stream info " + rtmpUrl + " error code:" + ret
-						+ " description: " + new String(data));
+				logger.warn("could not find stream info " + rtmpUrl + ERROR_CODE + ret
+						+ DESCRIPTION + new String(data));
 				return null;
 			}
 
@@ -335,8 +337,8 @@ public class PacketSenderRunnable implements Runnable {
 			if (ret < 0) {
 				byte[] data = new byte[4096];
 				avutil.av_strerror(ret, data, data.length);
-				logger.warn("could not create sdp " + rtmpUrl + " error code:" + ret
-						+ " description: " + new String(data));
+				logger.warn("could not create sdp " + rtmpUrl + ERROR_CODE + ret
+						+ DESCRIPTION + new String(data));
 				return null;
 			}
 

--- a/src/main/java/com/antstreaming/rtsp/RtspConnection.java
+++ b/src/main/java/com/antstreaming/rtsp/RtspConnection.java
@@ -36,6 +36,9 @@ import com.antstreaming.rtsp.session.DateUtil;
 
 public class RtspConnection  extends RTMPMinaConnection implements IMuxerListener {
 
+	private static final String CESQ_IS_NULL = "cesq is null...................";
+	private static final String SESSIONKEY_IS_NULL = "sessionKey is null...................";
+
 	private Logger logger = LoggerFactory.getLogger(RtspConnection.class);
 
 	protected static final String SLASH = "/";
@@ -129,7 +132,7 @@ public class RtspConnection  extends RTMPMinaConnection implements IMuxerListene
 
 		String sessionKey = request.getHeader(RtspHeaderCode.SESSION);
 		if (null == sessionKey || "".equals(sessionKey) || mSessionKey == null || !mSessionKey.equals(sessionKey)) {
-			logger.error("sessionKey is null...................");
+			logger.error(SESSIONKEY_IS_NULL);
 			handleError(session, cseq, RtspCode.SessionNotFound);
 			return;
 		}
@@ -259,14 +262,14 @@ public class RtspConnection  extends RTMPMinaConnection implements IMuxerListene
 		// get cesq
 		String cseq = request.getHeader(RtspHeaderCode.CSEQ);
 		if (null == cseq || "".equals(cseq)) {
-			logger.error("cesq is null...................");
+			logger.error(CESQ_IS_NULL);
 			handleError(session, "0", RtspCode.HeaderFieldNotValidForResource);
 			return;
 		}
 		// getsessionKey
 		String sessionKey = request.getHeader(RtspHeaderCode.SESSION);
 		if (null == sessionKey || "".equals(sessionKey) || !mSessionKey.equals(sessionKey)) {
-			logger.error("sessionKey is null...................");
+			logger.error(SESSIONKEY_IS_NULL);
 			handleError(session, cseq, RtspCode.SessionNotFound);
 			return;
 		}
@@ -506,7 +509,7 @@ public class RtspConnection  extends RTMPMinaConnection implements IMuxerListene
 		clientPort[streamId] = rtspTransport.getClientPort();
 		mode = rtspTransport.getMode();
 
-		if (mode != null && mode.equals("record")) {
+		if ("record".equals(mode)) {
 			//TODO check the url and do this operation according to the control parameter in the sdp
 
 			int portNo = PORT_NUMBER.getAndAdd(2);
@@ -566,7 +569,7 @@ public class RtspConnection  extends RTMPMinaConnection implements IMuxerListene
 		// get cesq
 		String cseq = request.getHeader(RtspHeaderCode.CSEQ);
 		if (null == cseq || "".equals(cseq)) {
-			logger.error("cesq is null...................");
+			logger.error(CESQ_IS_NULL);
 			handleError(session, "0", RtspCode.HeaderFieldNotValidForResource);
 			return;
 		}
@@ -574,7 +577,7 @@ public class RtspConnection  extends RTMPMinaConnection implements IMuxerListene
 		// get sessionKey
 		String sessionKey = request.getHeader(RtspHeaderCode.SESSION);
 		if (null == sessionKey || "".equals(sessionKey) || mSessionKey == null || !mSessionKey.equals(sessionKey)) {
-			logger.error("sessionKey is null...................");
+			logger.error(SESSIONKEY_IS_NULL);
 			handleError(session, cseq, RtspCode.SessionNotFound);
 			return;
 		}
@@ -621,7 +624,7 @@ public class RtspConnection  extends RTMPMinaConnection implements IMuxerListene
 		// get cesq
 		String cseq = request.getHeader(RtspHeaderCode.CSEQ);
 		if (null == cseq || "".equals(cseq)) {
-			logger.error("cesq is null...................");
+			logger.error(CESQ_IS_NULL);
 			handleError(session, "0", RtspCode.HeaderFieldNotValidForResource);
 			return;
 		}
@@ -638,7 +641,7 @@ public class RtspConnection  extends RTMPMinaConnection implements IMuxerListene
 		// get sessionKey
 		String sessionKey = request.getHeader(RtspHeaderCode.SESSION);
 		if (null == sessionKey || "".equals(sessionKey) || mSessionKey == null || !mSessionKey.equals(sessionKey)) {
-			logger.debug("sessionKey is null...................");
+			logger.debug(SESSIONKEY_IS_NULL);
 			handleError(session, cseq, RtspCode.SessionNotFound);
 		}
 		else {
@@ -679,7 +682,7 @@ public class RtspConnection  extends RTMPMinaConnection implements IMuxerListene
 		// get cesq
 		String cseq = request.getHeader(RtspHeaderCode.CSEQ);
 		if (null == cseq || "".equals(cseq)) {
-			logger.error("cesq is null...................");
+			logger.error(CESQ_IS_NULL);
 			handleError(session, "0", RtspCode.HeaderFieldNotValidForResource);
 			return;
 		}

--- a/src/main/java/com/antstreaming/rtsp/RtspConnectionManager.java
+++ b/src/main/java/com/antstreaming/rtsp/RtspConnectionManager.java
@@ -17,6 +17,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 public class RtspConnectionManager implements IConnectionManager<RtspConnection>, ApplicationContextAware {
 
+	private static final String NOT_IMPLEMENTED = "Not implemented";
+
 	private static Logger logger = LoggerFactory.getLogger(RtspConnectionManager.class);
 
 	protected ConcurrentMap<String, RtspConnection> connMap = new ConcurrentHashMap<String, RtspConnection>();
@@ -76,12 +78,12 @@ public class RtspConnectionManager implements IConnectionManager<RtspConnection>
 
 	@Override
 	public RtspConnection getConnection(int clientId) {
-		throw new UnsupportedOperationException("Not implemented");
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	@Override
 	public void setConnection(RtspConnection conn) {
-		throw new UnsupportedOperationException("Not implemented");
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 
 	}
 
@@ -120,12 +122,12 @@ public class RtspConnectionManager implements IConnectionManager<RtspConnection>
 
 	@Override
 	public RtspConnection createConnection(Class<?> connCls, String sessionId) {
-		throw new UnsupportedOperationException("Not implemented");
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	@Override
 	public RtspConnection removeConnection(int clientId) {
-		throw new UnsupportedOperationException("Not implemented");
+		throw new UnsupportedOperationException(NOT_IMPLEMENTED);
 	}
 
 	@Override

--- a/src/main/java/com/antstreaming/rtsp/protocol/RtspDecoder.java
+++ b/src/main/java/com/antstreaming/rtsp/protocol/RtspDecoder.java
@@ -18,6 +18,8 @@ import org.slf4j.LoggerFactory;
 
 
 public class RtspDecoder extends CumulativeProtocolDecoder {
+
+	private static final String RTSPMESSAGE = "rtspMessage";
 	private static Logger logger = LoggerFactory.getLogger(RtspDecoder.class);
 
 	/**
@@ -105,7 +107,7 @@ public class RtspDecoder extends CumulativeProtocolDecoder {
 						Matcher m = rtspResponsePattern.matcher(line);
 						if (!m.matches()) {
 							session.removeAttribute("state");
-							session.removeAttribute("rtspMessage");
+							session.removeAttribute(RTSPMESSAGE);
 							throw new ProtocolDecoderException("Malformed response line: " + line);
 						}
 
@@ -118,7 +120,7 @@ public class RtspDecoder extends CumulativeProtocolDecoder {
 						Matcher m = rtspRequestPattern.matcher(line);
 						if (!m.matches()) {
 							session.removeAttribute("state");
-							session.removeAttribute("rtspMessage");
+							session.removeAttribute(RTSPMESSAGE);
 							throw new ProtocolDecoderException("Malformed request line: " + line);
 						}
 
@@ -135,7 +137,7 @@ public class RtspDecoder extends CumulativeProtocolDecoder {
 
 						if (((RtspRequest) rtspMessage).getVerb() == RtspRequest.Verb.None) {
 							session.removeAttribute("state");
-							session.removeAttribute("rtspMessage");
+							session.removeAttribute(RTSPMESSAGE);
 							logger.error("Invalid method: " + verb);
 							throw new ProtocolDecoderException("Invalid method: " + verb);
 						}
@@ -150,7 +152,7 @@ public class RtspDecoder extends CumulativeProtocolDecoder {
 
 					if (!m.matches()) {
 						session.removeAttribute("state");
-						session.removeAttribute("rtspMessage");
+						session.removeAttribute(RTSPMESSAGE);
 						// logger.error("RTSP header not valid line:" + line);
 						throw new ProtocolDecoderException("RTSP header not valid line:" + line);
 					}
@@ -203,7 +205,7 @@ public class RtspDecoder extends CumulativeProtocolDecoder {
 			// The message is already formed
 			// send it
 			session.removeAttribute("state");
-			session.removeAttribute("rtspMessage");
+			session.removeAttribute(RTSPMESSAGE);
 			out.write(rtspMessage);
 			return true;
 		}
@@ -212,7 +214,7 @@ public class RtspDecoder extends CumulativeProtocolDecoder {
 
 		// Save attributes in session
 		session.setAttribute("state", state);
-		session.setAttribute("rtspMessage", rtspMessage);
+		session.setAttribute(RTSPMESSAGE, rtspMessage);
 		return false;
 	}
 }

--- a/src/main/java/org/red5/logging/DerbyLogInterceptor.java
+++ b/src/main/java/org/red5/logging/DerbyLogInterceptor.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 
 public class DerbyLogInterceptor {
 
+	private static final String DERBY_LOG = "Derby log: {}";
+
     protected static Logger log = LoggerFactory.getLogger(DerbyLogInterceptor.class);
 
     private static ThreadLocal<StringBuilder> local = new ThreadLocal<>();
@@ -35,7 +37,7 @@ public class DerbyLogInterceptor {
 
             @Override
             public void write(byte[] b) throws IOException {
-                log.info("Derby log: {}", new String(b));
+                log.info(DERBY_LOG, new String(b));
             }
 
             @Override
@@ -46,10 +48,10 @@ public class DerbyLogInterceptor {
                 }
                 //look for LF
                 if (i == 10) {
-                    log.info("Derby log: {}", sb.toString());
+                    log.info(DERBY_LOG, sb.toString());
                     sb.delete(0, sb.length() - 1);
                 } else {
-                    log.trace("Derby log: {}", i);
+                    log.trace(DERBY_LOG, i);
                     sb.append(new String(intToDWord(i)));
                 }
                 local.set(sb);

--- a/src/main/java/org/red5/server/ContextLoader.java
+++ b/src/main/java/org/red5/server/ContextLoader.java
@@ -59,6 +59,9 @@ import org.springframework.web.context.support.XmlWebApplicationContext;
 @ManagedResource(objectName = "org.red5.server:name=contextLoader,type=ContextLoader", description = "ContextLoader")
 public class ContextLoader implements ApplicationContextAware, InitializingBean, DisposableBean, ContextLoaderMXBean {
 
+	private static final String FILE = "file://";
+	private static final String RED5_COMMON = "red5.common";
+
     protected static Logger log = Red5LoggerFactory.getLogger(ContextLoader.class);
 
     /**
@@ -165,11 +168,11 @@ public class ContextLoader implements ApplicationContextAware, InitializingBean,
             File configFile = new File(config);
             if (!configFile.exists()) {
                 log.warn("Config file was not found at: {}", configFile.getCanonicalPath());
-                configFile = new File("file://" + config);
+                configFile = new File(FILE + config);
                 if (!configFile.exists()) {
                     log.warn("Config file was not found at either: {}", configFile.getCanonicalPath());
                 } else {
-                    config = "file://" + config;
+                    config = FILE + config;
                 }
             }
         } catch (IOException e) {
@@ -183,14 +186,14 @@ public class ContextLoader implements ApplicationContextAware, InitializingBean,
         }
         // if parent context was not set then lookup red5.common
         if (parentContext == null) {
-            log.debug("Lookup common - bean:{} local:{} singleton:{}", new Object[] { factory.containsBean("red5.common"), factory.containsLocalBean("red5.common"), factory.containsSingleton("red5.common"), });
-            parentContext = (ApplicationContext) factory.getBean("red5.common");
+            log.debug("Lookup common - bean:{} local:{} singleton:{}", new Object[] { factory.containsBean(RED5_COMMON), factory.containsLocalBean(RED5_COMMON), factory.containsSingleton(RED5_COMMON), });
+            parentContext = (ApplicationContext) factory.getBean(RED5_COMMON);
         }
         if (config.startsWith("/")) {
             // Spring always interprets files as relative, so will strip a leading slash unless we tell
             // it otherwise. It also appears to not need this for Windows
             // absolute paths (e.g. C:\Foo\Bar) so we don't catch that either
-            String newConfig = "file://" + config;
+            String newConfig = FILE + config;
             log.debug("Resetting {} to {}", config, newConfig);
             config = newConfig;
         }

--- a/src/main/java/org/red5/server/adapter/MultiThreadedApplicationAdapter.java
+++ b/src/main/java/org/red5/server/adapter/MultiThreadedApplicationAdapter.java
@@ -124,6 +124,8 @@ public class MultiThreadedApplicationAdapter extends StatefulScopeWrappingAdapte
 		IBroadcastStreamService, IOnDemandStreamService, ISubscriberStreamService, ISchedulingService,
 		IStreamSecurityService, ISharedObjectSecurityService, IStreamAwareScopeHandler, ApplicationMXBean {
 
+	private static final String _0_0_0_0 = "0.0.0.0";
+
 	/**
 	 * Logger object
 	 */
@@ -1413,7 +1415,7 @@ public class MultiThreadedApplicationAdapter extends StatefulScopeWrappingAdapte
 		// log w3c connect event
 		IConnection connection = Red5.getConnectionLocal();
 		log.info("W3C x-category:stream x-event:publish c-ip:{} x-sname:{} x-name:{}",
-				new Object[] { connection != null ? connection.getRemoteAddress() : "0.0.0.0", stream.getName(),
+				new Object[] { connection != null ? connection.getRemoteAddress() : _0_0_0_0, stream.getName(),
 						stream.getPublishedName() });
 	}
 
@@ -1421,7 +1423,7 @@ public class MultiThreadedApplicationAdapter extends StatefulScopeWrappingAdapte
 		// log w3c connect event
 		IConnection connection = Red5.getConnectionLocal();
 		log.info("W3C x-category:stream x-event:record-start c-ip:{} x-sname:{} x-file-name:{}",
-				new Object[] { connection != null ? connection.getRemoteAddress() : "0.0.0.0", stream.getName(),
+				new Object[] { connection != null ? connection.getRemoteAddress() : _0_0_0_0, stream.getName(),
 						stream.getSaveFilename() });
 	}
 
@@ -1429,7 +1431,7 @@ public class MultiThreadedApplicationAdapter extends StatefulScopeWrappingAdapte
 		// log w3c connect event
 		IConnection connection = Red5.getConnectionLocal();
 		log.info("W3C x-category:stream x-event:record-stop c-ip:{} x-sname:{} x-file-name:{}",
-				new Object[] { connection != null ? connection.getRemoteAddress() : "0.0.0.0", stream.getName(),
+				new Object[] { connection != null ? connection.getRemoteAddress() : _0_0_0_0, stream.getName(),
 						stream.getSaveFilename() });
 	}
 

--- a/src/main/java/org/red5/server/jmx/JMXUtil.java
+++ b/src/main/java/org/red5/server/jmx/JMXUtil.java
@@ -40,6 +40,9 @@ import org.slf4j.LoggerFactory;
  */
 public class JMXUtil {
 
+    private static final String DESCR_T = "    DESCR: \t";
+    private static final String NAME_T = " ** NAME: \t";
+
     private static Logger log = LoggerFactory.getLogger(JMXUtil.class);
 
     public static void printMBeanInfo(ObjectName objectName, String className) {
@@ -59,8 +62,8 @@ public class JMXUtil {
         MBeanAttributeInfo[] attrInfo = info.getAttributes();
         if (attrInfo.length > 0) {
             for (int i = 0; i < attrInfo.length; i++) {
-                log.info(" ** NAME: \t" + attrInfo[i].getName());
-                log.info("    DESCR: \t" + attrInfo[i].getDescription());
+                log.info(NAME_T + attrInfo[i].getName());
+                log.info(DESCR_T + attrInfo[i].getDescription());
                 log.info("    TYPE: \t" + attrInfo[i].getType() + "\tREAD: " + attrInfo[i].isReadable() + "\tWRITE: " + attrInfo[i].isWritable());
             }
         } else
@@ -68,16 +71,16 @@ public class JMXUtil {
         log.info("CONSTRUCTORS");
         MBeanConstructorInfo[] constrInfo = info.getConstructors();
         for (int i = 0; i < constrInfo.length; i++) {
-            log.info(" ** NAME: \t" + constrInfo[i].getName());
-            log.info("    DESCR: \t" + constrInfo[i].getDescription());
+            log.info(NAME_T + constrInfo[i].getName());
+            log.info(DESCR_T + constrInfo[i].getDescription());
             log.info("    PARAM: \t" + constrInfo[i].getSignature().length + " parameter(s)");
         }
         log.info("OPERATIONS");
         MBeanOperationInfo[] opInfo = info.getOperations();
         if (opInfo.length > 0) {
             for (int i = 0; i < opInfo.length; i++) {
-                log.info(" ** NAME: \t" + opInfo[i].getName());
-                log.info("    DESCR: \t" + opInfo[i].getDescription());
+                log.info(NAME_T + opInfo[i].getName());
+                log.info(DESCR_T + opInfo[i].getDescription());
                 log.info("    PARAM: \t" + opInfo[i].getSignature().length + " parameter(s)");
             }
         } else
@@ -86,8 +89,8 @@ public class JMXUtil {
         MBeanNotificationInfo[] notifInfo = info.getNotifications();
         if (notifInfo.length > 0) {
             for (int i = 0; i < notifInfo.length; i++) {
-                log.info(" ** NAME: \t" + notifInfo[i].getName());
-                log.info("    DESCR: \t" + notifInfo[i].getDescription());
+                log.info(NAME_T + notifInfo[i].getName());
+                log.info(DESCR_T + notifInfo[i].getDescription());
                 String notifTypes[] = notifInfo[i].getNotifTypes();
                 for (int j = 0; j < notifTypes.length; j++) {
                     log.info("    TYPE: \t" + notifTypes[j]);

--- a/src/main/java/org/red5/server/net/rtmpt/RTMPTServlet.java
+++ b/src/main/java/org/red5/server/net/rtmpt/RTMPTServlet.java
@@ -60,6 +60,12 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
  */
 public class RTMPTServlet extends HttpServlet {
 
+    private static final String CONNECTION = "Connection";
+    private static final String NO_CACHE = "no-cache";
+    private static final String CACHE_CONTROL = "Cache-Control";
+    private static final String RETURNMESSAGE = "returnMessage {}";
+    private static final String KEEP_ALIVE = "Keep-Alive";
+
     private static final long serialVersionUID = 5925399677454936613L;
 
     protected static Logger log = Red5LoggerFactory.getLogger(RTMPTServlet.class);
@@ -165,10 +171,10 @@ public class RTMPTServlet extends HttpServlet {
      *             I/O exception
      */
     protected void returnMessage(byte message, HttpServletResponse resp) throws IOException {
-        log.debug("returnMessage {}", message);
+        log.debug(RETURNMESSAGE, message);
         resp.setStatus(HttpServletResponse.SC_OK);
-        resp.setHeader("Connection", "Keep-Alive");
-        resp.setHeader("Cache-Control", "no-cache");
+        resp.setHeader(CONNECTION, KEEP_ALIVE);
+        resp.setHeader(CACHE_CONTROL, NO_CACHE);
         resp.setContentType(CONTENT_TYPE);
         resp.setContentLength(1);
         resp.getWriter().write(message);
@@ -186,10 +192,10 @@ public class RTMPTServlet extends HttpServlet {
      *             I/O exception
      */
     protected void returnMessage(String message, HttpServletResponse resp) throws IOException {
-        log.debug("returnMessage {}", message);
+        log.debug(RETURNMESSAGE, message);
         resp.setStatus(HttpServletResponse.SC_OK);
-        resp.setHeader("Connection", "Keep-Alive");
-        resp.setHeader("Cache-Control", "no-cache");
+        resp.setHeader(CONNECTION, KEEP_ALIVE);
+        resp.setHeader(CACHE_CONTROL, NO_CACHE);
         resp.setContentType(CONTENT_TYPE);
         resp.setContentLength(message.length());
         resp.getWriter().write(message);
@@ -209,14 +215,14 @@ public class RTMPTServlet extends HttpServlet {
      *             I/O exception
      */
     protected void returnMessage(RTMPTConnection conn, IoBuffer buffer, HttpServletResponse resp) throws IOException {
-        log.trace("returnMessage {}", buffer);
+        log.trace(RETURNMESSAGE, buffer);
         if (conn != null) {
             resp.setStatus(HttpServletResponse.SC_OK);
         } else {
             resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         }
-        resp.setHeader("Connection", "Keep-Alive");
-        resp.setHeader("Cache-Control", "no-cache");
+        resp.setHeader(CONNECTION, KEEP_ALIVE);
+        resp.setHeader(CACHE_CONTROL, NO_CACHE);
         resp.setContentType(CONTENT_TYPE);
         int contentLength = buffer.limit() + 1;
         resp.setContentLength(contentLength);
@@ -352,8 +358,8 @@ public class RTMPTServlet extends HttpServlet {
             }
         } else {
             resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            resp.setHeader("Connection", "Keep-Alive");
-            resp.setHeader("Cache-Control", "no-cache");
+            resp.setHeader(CONNECTION, KEEP_ALIVE);
+            resp.setHeader(CACHE_CONTROL, NO_CACHE);
             resp.flushBuffer();
         }
     }
@@ -603,15 +609,15 @@ public class RTMPTServlet extends HttpServlet {
                     } else {
                         // just send 404 back if no ident2 value is set
                         resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
-                        resp.setHeader("Connection", "Keep-Alive");
-                        resp.setHeader("Cache-Control", "no-cache");
+                        resp.setHeader(CONNECTION, KEEP_ALIVE);
+                        resp.setHeader(CACHE_CONTROL, NO_CACHE);
                         resp.flushBuffer();
                         break;
                     }
                 }
                 resp.setStatus(HttpServletResponse.SC_OK);
-                resp.setHeader("Connection", "Keep-Alive");
-                resp.setHeader("Cache-Control", "no-cache");
+                resp.setHeader(CONNECTION, KEEP_ALIVE);
+                resp.setHeader(CACHE_CONTROL, NO_CACHE);
                 resp.setContentType(CONTENT_TYPE);
                 resp.setContentLength(ident.length());
                 resp.getWriter().write(ident);

--- a/src/main/java/org/red5/server/scheduling/ApplicationSchedulingService.java
+++ b/src/main/java/org/red5/server/scheduling/ApplicationSchedulingService.java
@@ -41,6 +41,8 @@ import org.springframework.jmx.export.annotation.ManagedResource;
 @ManagedResource(objectName = "org.red5.server:type=ApplicationSchedulingService,name=default")
 public class ApplicationSchedulingService extends QuartzSchedulingService {
 
+    private static final String ORG_RED5_SERVER_TYPE_APPLICATIONSCHEDULINGSERVICE_APPLICATIONNAME = "org.red5.server:type=ApplicationSchedulingService,applicationName=";
+
     private static Logger log = Red5LoggerFactory.getLogger(ApplicationSchedulingService.class);
 
     public static final String QUARTZ_FACTORY_KEY = "org.quartz.impl.StdSchedulerFactory.KEY";
@@ -106,9 +108,9 @@ public class ApplicationSchedulingService extends QuartzSchedulingService {
         try {
             ObjectName oName = null;
             if (instanceId == null) {
-                oName = new ObjectName("org.red5.server:type=ApplicationSchedulingService,applicationName=" + applicationName);
+                oName = new ObjectName(ORG_RED5_SERVER_TYPE_APPLICATIONSCHEDULINGSERVICE_APPLICATIONNAME + applicationName);
             } else {
-                oName = new ObjectName("org.red5.server:type=ApplicationSchedulingService,applicationName=" + applicationName + ",instanceId=" + instanceId);
+                oName = new ObjectName(ORG_RED5_SERVER_TYPE_APPLICATIONSCHEDULINGSERVICE_APPLICATIONNAME + applicationName + ",instanceId=" + instanceId);
             }
             mbeanServer.registerMBean(new StandardMBean(this, QuartzSchedulingServiceMXBean.class, true), oName);
         } catch (Exception e) {
@@ -121,9 +123,9 @@ public class ApplicationSchedulingService extends QuartzSchedulingService {
         try {
             ObjectName oName = null;
             if (instanceId == null) {
-                oName = new ObjectName("org.red5.server:type=ApplicationSchedulingService,applicationName=" + applicationName);
+                oName = new ObjectName(ORG_RED5_SERVER_TYPE_APPLICATIONSCHEDULINGSERVICE_APPLICATIONNAME + applicationName);
             } else {
-                oName = new ObjectName("org.red5.server:type=ApplicationSchedulingService,applicationName=" + applicationName + ",instanceId=" + instanceId);
+                oName = new ObjectName(ORG_RED5_SERVER_TYPE_APPLICATIONSCHEDULINGSERVICE_APPLICATIONNAME + applicationName + ",instanceId=" + instanceId);
             }
             mbs.unregisterMBean(oName);
         } catch (Exception e) {

--- a/src/main/java/org/red5/server/service/Installer.java
+++ b/src/main/java/org/red5/server/service/Installer.java
@@ -55,6 +55,8 @@ import org.slf4j.Logger;
  */
 public final class Installer {
 
+    private static final String ONALERT = "onAlert";
+
     private static Logger log = Red5LoggerFactory.getLogger(Installer.class);
 
     private String applicationRepositoryUrl;
@@ -184,7 +186,7 @@ public final class Installer {
             } else {
                 log.warn("Application destination is not a directory");
             }
-            ServiceUtils.invokeOnConnection(conn, "onAlert", new Object[] { String.format("Application %s already installed, please un-install before attempting another install", application) });
+            ServiceUtils.invokeOnConnection(conn, ONALERT, new Object[] { String.format("Application %s already installed, please un-install before attempting another install", application) });
         } else {
             //use the system temp directory for moving files around
             String srcDir = System.getProperty("java.io.tmpdir");
@@ -283,12 +285,12 @@ public final class Installer {
                     //just copy the war to the webapps dir
                     try {
                         FileUtil.moveFile(srcDir + '/' + applicationWarName, webappsDir + '/' + application + ".war");
-                        ServiceUtils.invokeOnConnection(conn, "onAlert", new Object[] { String.format("Application %s will not be available until container is restarted", application) });
+                        ServiceUtils.invokeOnConnection(conn, ONALERT, new Object[] { String.format("Application %s will not be available until container is restarted", application) });
                     } catch (IOException e) {
                     }
                 }
             }
-            ServiceUtils.invokeOnConnection(conn, "onAlert", new Object[] { String.format("Application %s was %s", application, (result ? "installed" : "not installed")) });
+            ServiceUtils.invokeOnConnection(conn, ONALERT, new Object[] { String.format("Application %s was %s", application, (result ? "installed" : "not installed")) });
         }
         appDir = null;
         return result;
@@ -302,7 +304,7 @@ public final class Installer {
      * @return true if uninstalled; else false
      */
     public boolean uninstall(String applicationName) {
-        ServiceUtils.invokeOnConnection(Red5.getConnectionLocal(), "onAlert", new Object[] { "Uninstall function not available" });
+        ServiceUtils.invokeOnConnection(Red5.getConnectionLocal(), ONALERT, new Object[] { "Uninstall function not available" });
         return false;
     }
 

--- a/src/main/java/org/red5/server/stream/ServerStream.java
+++ b/src/main/java/org/red5/server/stream/ServerStream.java
@@ -73,6 +73,8 @@ import org.slf4j.LoggerFactory;
  */
 public class ServerStream extends AbstractStream implements IServerStream, IFilter, IPushableConsumer, IPipeConnectionListener {
 
+    private static final String ERROR_WHILE_SENDING_MESSAGE = "Error while sending message.";
+
     private static final Logger log = LoggerFactory.getLogger(ServerStream.class);
 
     private static final long WAIT_THRESHOLD = 0;
@@ -784,7 +786,7 @@ public class ServerStream extends AbstractStream implements IServerStream, IFilt
             try {
                 pushMessage(nextRTMPMessage);
             } catch (IOException err) {
-                log.error("Error while sending message.", err);
+                log.error(ERROR_WHILE_SENDING_MESSAGE, err);
             }
             nextRTMPMessage.getBody().release();
         }
@@ -864,7 +866,7 @@ public class ServerStream extends AbstractStream implements IServerStream, IFilt
             try {
                 pushMessage(nextRTMPMessage);
             } catch (IOException err) {
-                log.error("Error while sending message.", err);
+                log.error(ERROR_WHILE_SENDING_MESSAGE, err);
             }
             nextRTMPMessage.getBody().release();
             nextRTMPMessage = null;
@@ -873,7 +875,7 @@ public class ServerStream extends AbstractStream implements IServerStream, IFilt
         try {
             pushMessage(reset);
         } catch (IOException err) {
-            log.error("Error while sending message.", err);
+            log.error(ERROR_WHILE_SENDING_MESSAGE, err);
         }
         scheduleNextMessage();
     }

--- a/src/test/java/io/antmedia/test/AntMediaApplicationAdaptorUnitTest.java
+++ b/src/test/java/io/antmedia/test/AntMediaApplicationAdaptorUnitTest.java
@@ -43,6 +43,8 @@ import io.vertx.core.Vertx;
 
 public class AntMediaApplicationAdaptorUnitTest {
 
+    private static final String ACTION = "action";
+
 	AntMediaApplicationAdapter adapter;
 	String streamsFolderPath = "webapps/test/streams";
 
@@ -202,7 +204,7 @@ public class AntMediaApplicationAdaptorUnitTest {
 			Mockito.when(entity.getContent()).thenReturn(is);
 			Mockito.when(httpResponse.getEntity()).thenReturn(entity);
 			HashMap map = new HashMap();
-			map.put("action", "action_any");
+			map.put(ACTION, "action_any");
 			response = spyAdaptor.sendPOST("http://any_url", map);
 			assertNotNull(response);
 			assertEquals(10, response.length());
@@ -246,7 +248,7 @@ public class AntMediaApplicationAdaptorUnitTest {
 
 			Map variablesMap = variables.getValue();
 			assertEquals(id, variablesMap.get("id"));
-			assertEquals(action, variablesMap.get("action"));
+			assertEquals(action, variablesMap.get(ACTION));
 			assertEquals(streamName, variablesMap.get("streamName"));
 			assertEquals(category, variablesMap.get("category"));
 			assertEquals(vodName, variablesMap.get("vodName"));
@@ -270,7 +272,7 @@ public class AntMediaApplicationAdaptorUnitTest {
 
 			Map variablesMap = variables.getValue();
 			assertEquals(id, variablesMap.get("id"));
-			assertNull(variablesMap.get("action"));
+			assertNull(variablesMap.get(ACTION));
 			assertNull(variablesMap.get("streamName"));
 			assertNull(variablesMap.get("category"));
 			assertNull(variablesMap.get("vodName"));

--- a/src/test/java/io/antmedia/test/db/DataStoreFactoryUnitTest.java
+++ b/src/test/java/io/antmedia/test/db/DataStoreFactoryUnitTest.java
@@ -26,6 +26,8 @@ import io.antmedia.security.ExpireStreamPublishSecurity;
 import io.antmedia.statistic.HlsViewerStats;
 
 public class DataStoreFactoryUnitTest {
+
+    private static final String MEMORYDB = "memorydb";
 	private DataStoreFactory dsf;
 
 	@Before
@@ -55,7 +57,7 @@ public class DataStoreFactoryUnitTest {
 	
     @Test
     public void testDBCreation() {
-    	dsf.setDbType("memorydb");
+    	dsf.setDbType(MEMORYDB);
     	assertTrue(dsf.getDataStore() instanceof InMemoryDataStore);
     	
     	dsf.setDataStore(null);
@@ -75,7 +77,7 @@ public class DataStoreFactoryUnitTest {
     
     @Test
     public void testForUsedClases() {
-    	dsf.setDbType("memorydb");
+    	dsf.setDbType(MEMORYDB);
     	DataStore datastore = dsf.getDataStore();
     	
     	AcceptOnlyStreamsInDataStore aosid = new AcceptOnlyStreamsInDataStore();
@@ -107,7 +109,7 @@ public class DataStoreFactoryUnitTest {
     
     @Test
     public void testDBReader() {
-    	dsf.setDbType("memorydb");
+    	dsf.setDbType(MEMORYDB);
     	DataStore datastore = dsf.getDataStore();
     	
     	String host = DBReader.instance.getHost("myStream", "myApp");

--- a/src/test/java/io/antmedia/test/launcher/LauncherUnitTest.java
+++ b/src/test/java/io/antmedia/test/launcher/LauncherUnitTest.java
@@ -23,6 +23,8 @@ import io.antmedia.AsciiArt;
 @ContextConfiguration(locations = { "test.xml" })
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public class LauncherUnitTest {
+
+    private static final String VERSION = "version";
 	
 	protected WebScope appScope;
 	static {
@@ -50,17 +52,17 @@ public class LauncherUnitTest {
 			
 			Launcher.setInstanceIdFilePath("target/instanceId");
 			
-			assertTrue(launcher.notifyShutDown("version", "type"));
+			assertTrue(launcher.notifyShutDown(VERSION, "type"));
 			
-			assertTrue(launcher.startAnalytic("version", "type"));	
+			assertTrue(launcher.startAnalytic(VERSION, "type"));	
 			
-			assertTrue(launcher.startHeartBeats("version", "type", 1000));
+			assertTrue(launcher.startHeartBeats(VERSION, "type", 1000));
 			
 
 			Awaitility.await().with().pollDelay(10,TimeUnit.SECONDS).atMost(20, TimeUnit.SECONDS)
 			.pollInterval(1, TimeUnit.SECONDS)
 			.until(()->{
-				return launcher.startHeartBeats("version", "type", 1000);
+				return launcher.startHeartBeats(VERSION, "type", 1000);
 			});
 
 	}

--- a/src/test/java/io/antmedia/test/preference/PreferenceStoreTest.java
+++ b/src/test/java/io/antmedia/test/preference/PreferenceStoreTest.java
@@ -16,6 +16,9 @@ import io.antmedia.datastore.preference.PreferenceStore;
 
 public class PreferenceStoreTest {
 
+    private static final String VALUE1 = "value1";
+    private static final String DATA_PROPERTIES = "data.properties";
+
 
 	@Test
 	public void testStorePreferences() {
@@ -28,24 +31,24 @@ public class PreferenceStoreTest {
 				Files.delete(f.toPath());
 			}
 
-			PreferenceStore dataStore = new PreferenceStore("data.properties");
+			PreferenceStore dataStore = new PreferenceStore(DATA_PROPERTIES);
 			dataStore.setFullPath(fullPath);
 			assertNull(dataStore.get("data1"));
 
-			dataStore.put("data1", "value1");
+			dataStore.put("data1", VALUE1);
 			dataStore.put("data2", "value2");
 			dataStore.put("data3", "value3");
 
-			assertEquals(dataStore.get("data1"), "value1");
+			assertEquals(dataStore.get("data1"), VALUE1);
 
 			assertTrue(dataStore.save());
 
-			assertEquals(dataStore.get("data1"), "value1");
+			assertEquals(dataStore.get("data1"), VALUE1);
 
-			dataStore = new PreferenceStore("data.properties");
+			dataStore = new PreferenceStore(DATA_PROPERTIES);
 			dataStore.setFullPath(fullPath);
 			assertNotNull(dataStore.get("data1"));
-			assertEquals(dataStore.get("data1"), "value1");
+			assertEquals(dataStore.get("data1"), VALUE1);
 			dataStore.put("data4", "value4");
 			assertTrue(dataStore.save());
 
@@ -56,13 +59,13 @@ public class PreferenceStoreTest {
 			assertNull(dataStore.get("data4"));
 			
 			//create store with full path
-			dataStore = new PreferenceStore("data.properties", true);
+			dataStore = new PreferenceStore(DATA_PROPERTIES, true);
 			
-			dataStore.put("data1", "value1");
+			dataStore.put("data1", VALUE1);
 			
 			assertTrue(dataStore.save());
 			assertNotNull(dataStore.get("data1"));
-			assertEquals( "value1", dataStore.get("data1"));
+			assertEquals( VALUE1, dataStore.get("data1"));
 
 
 		} catch (IOException e) {

--- a/src/test/java/io/antmedia/test/rest/StreamSourceRestServiceUnitTest.java
+++ b/src/test/java/io/antmedia/test/rest/StreamSourceRestServiceUnitTest.java
@@ -44,6 +44,8 @@ import io.antmedia.test.StreamFetcherUnitTest;
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public class StreamSourceRestServiceUnitTest {
 
+    private static final String ENDPOINT_1 = "endpoint_1";
+
 	protected static Logger logger = LoggerFactory.getLogger(StreamSourceRestServiceUnitTest.class);
 	private StreamsSourceRestService restService = null;
 	public AntMediaApplicationAdapter app = null;
@@ -318,7 +320,7 @@ public class StreamSourceRestServiceUnitTest {
 		when(monitorService.getAvgCpuUsage()).thenReturn(cpuLoad2);
 		when(monitorService.getCpuLimit()).thenReturn(cpuLimit2);
 		
-		result = streamSourceRest.addStreamSource(source, "endpoint_1");
+		result = streamSourceRest.addStreamSource(source, ENDPOINT_1);
 		assertNull(source.getEndPointList());
 
 
@@ -332,7 +334,7 @@ public class StreamSourceRestServiceUnitTest {
 			e.printStackTrace();
 		}
 
-		videoServiceEndpoints.put("endpoint_1", mockVSEndpoint);
+		videoServiceEndpoints.put(ENDPOINT_1, mockVSEndpoint);
 
 		//When there is an endpoint defined
 		Broadcast source2 = new Broadcast("test_2");
@@ -341,7 +343,7 @@ public class StreamSourceRestServiceUnitTest {
 		source2.setPublicStream(false);
 		source2.setType(AntMediaApplicationAdapter.STREAM_SOURCE);
 
-		result = streamSourceRest.addStreamSource(source2, "endpoint_1");
+		result = streamSourceRest.addStreamSource(source2, ENDPOINT_1);
 		assertEquals(1, source2.getEndPointList().size());
 
 		//Now we add second endpoint
@@ -358,7 +360,7 @@ public class StreamSourceRestServiceUnitTest {
 		assertEquals(2, source3.getEndPointList().size());
 
 		//update first source now. At the moment we have endpoint_1
-		result = streamSourceRest.updateCamInfo(source, "endpoint_1");
+		result = streamSourceRest.updateCamInfo(source, ENDPOINT_1);
 		assertEquals(1, source.getEndPointList().size());
 	}
 

--- a/src/test/java/io/antmedia/test/statistic/ResourceMonitorTest.java
+++ b/src/test/java/io/antmedia/test/statistic/ResourceMonitorTest.java
@@ -39,6 +39,8 @@ import io.vertx.core.Vertx;
 
 public class ResourceMonitorTest {
 
+    private static final String TARGET_INSTANCEID = "target/instanceId";
+
 	@Test
 	public void testCpuAverage() {
 		ResourceMonitor monitor = new ResourceMonitor();
@@ -97,7 +99,7 @@ public class ResourceMonitorTest {
 		assertTrue(jsObject.has(ResourceMonitor.FREE_SWAP_SPACE));
 		assertTrue(jsObject.has(ResourceMonitor.IN_USE_SWAP_SPACE));
 		
-		Launcher.setInstanceIdFilePath("target/instanceId");
+		Launcher.setInstanceIdFilePath(TARGET_INSTANCEID);
 		jsObject = ResourceMonitor.getSystemResourcesInfo(null);
 		assertTrue(jsObject.has(ResourceMonitor.CPU_USAGE));
 		assertTrue(jsObject.has(ResourceMonitor.JVM_MEMORY_USAGE));
@@ -169,7 +171,7 @@ public class ResourceMonitorTest {
 		
 		Mockito.when(kafkaProducer.send(any())).thenReturn(futureMetdata);
 		
-		Launcher.setInstanceIdFilePath("target/instanceId");
+		Launcher.setInstanceIdFilePath(TARGET_INSTANCEID);
 		resMonitor.setKafkaProducer(kafkaProducer);
 		resMonitor.sendInstanceStats(null);
 		
@@ -195,7 +197,7 @@ public class ResourceMonitorTest {
 		
 		Mockito.when(kafkaProducer.send(any())).thenReturn(futureMetdata);
 		
-		Launcher.setInstanceIdFilePath("target/instanceId");
+		Launcher.setInstanceIdFilePath(TARGET_INSTANCEID);
 		resMonitor.setKafkaProducer(kafkaProducer);
 		
 		List<WebRTCClientStats> webRTCClientStatList = new ArrayList<>();
@@ -211,7 +213,7 @@ public class ResourceMonitorTest {
 	
 	@Test
 	public void testCreateKafka() {
-		Launcher.setInstanceIdFilePath("target/instanceId");
+		Launcher.setInstanceIdFilePath(TARGET_INSTANCEID);
 		ResourceMonitor resMonitor = new ResourceMonitor();
 		try {
 			Producer<Long, String> kafkaProducer = resMonitor.createKafkaProducer();
@@ -230,7 +232,7 @@ public class ResourceMonitorTest {
 	
 	@Test
 	public void testCollectAndSendWebRTCStats() {
-		Launcher.setInstanceIdFilePath("target/instanceId");
+		Launcher.setInstanceIdFilePath(TARGET_INSTANCEID);
 		ResourceMonitor resMonitor = new ResourceMonitor();
 		Producer<Long, String> kafkaProducer = Mockito.mock(Producer.class);
 		resMonitor.setKafkaProducer(kafkaProducer);

--- a/src/test/java/io/antmedia/test/token/TokenFilterTest.java
+++ b/src/test/java/io/antmedia/test/token/TokenFilterTest.java
@@ -41,6 +41,8 @@ import io.antmedia.security.MockTokenService;
 
 
 public class TokenFilterTest {
+
+    private static final String LIVEAPP_STREAMS = "/liveapp/streams/";
 	protected static Logger logger = LoggerFactory.getLogger(TokenFilterTest.class);
 
 	private TokenFilterManager tokenFilter;
@@ -134,17 +136,17 @@ public class TokenFilterTest {
 	@Test
 	public void testGetStreamId() {
 		String streamId = "streamId";
-		assertEquals(streamId, TokenFilterManager.getStreamId("/liveapp/streams/"+streamId+"_davut_diyen_kedi_adaptive.m3u8"));
+		assertEquals(streamId, TokenFilterManager.getStreamId(LIVEAPP_STREAMS+streamId+"_davut_diyen_kedi_adaptive.m3u8"));
 
-		assertEquals(streamId, TokenFilterManager.getStreamId("/liveapp/streams/"+streamId+".m3u8"));
+		assertEquals(streamId, TokenFilterManager.getStreamId(LIVEAPP_STREAMS+streamId+".m3u8"));
 
-		assertEquals(streamId, TokenFilterManager.getStreamId("/liveapp/streams/"+streamId+".mp4"));
+		assertEquals(streamId, TokenFilterManager.getStreamId(LIVEAPP_STREAMS+streamId+".mp4"));
 
-		assertEquals(streamId, TokenFilterManager.getStreamId("/liveapp/streams/"+streamId+ MuxAdaptor.ADAPTIVE_SUFFIX + ".m3u8"));
+		assertEquals(streamId, TokenFilterManager.getStreamId(LIVEAPP_STREAMS+streamId+ MuxAdaptor.ADAPTIVE_SUFFIX + ".m3u8"));
 
-		assertEquals(streamId, TokenFilterManager.getStreamId("/liveapp/streams/"+streamId+"_240p.m3u8"));
+		assertEquals(streamId, TokenFilterManager.getStreamId(LIVEAPP_STREAMS+streamId+"_240p.m3u8"));
 
-		assertNull(TokenFilterManager.getStreamId("/liveapp/streams/"+streamId+".u8"));
+		assertNull(TokenFilterManager.getStreamId(LIVEAPP_STREAMS+streamId+".u8"));
 
 
 		//below test case

--- a/src/test/java/io/antmedia/test/token/TokenServiceTest.java
+++ b/src/test/java/io/antmedia/test/token/TokenServiceTest.java
@@ -28,6 +28,8 @@ import io.antmedia.filter.TokenSessionFilter;
 import io.antmedia.security.MockTokenService;
 
 public class TokenServiceTest {
+
+    private static final String STREAMID = "streamId";
 	protected static Logger logger = LoggerFactory.getLogger(TokenServiceTest.class);
 
 	DataStore datastore;
@@ -59,7 +61,7 @@ public class TokenServiceTest {
 		//create token
 		
 		Token token = new Token();
-		token.setStreamId("streamId");
+		token.setStreamId(STREAMID);
 		token.setTokenId("tokenId");
 		token.setType(Token.PLAY_TOKEN);
 
@@ -79,11 +81,11 @@ public class TokenServiceTest {
 
 		//create token
 		Token token = new Token();
-		token.setStreamId("streamId");
+		token.setStreamId(STREAMID);
 		token.setTokenId("tokenId");
 		token.setType(Token.PLAY_TOKEN);
 		
-		tokenService.getAuthenticatedMap().put("sessionId", "streamId");
+		tokenService.getAuthenticatedMap().put("sessionId", STREAMID);
 
 		//check that map size
 		assertEquals(1, tokenService.getAuthenticatedMap().size());


### PR DESCRIPTION
Extracting constants from Strings that were duplicated at least 3 times. Considering only Strings with length >= 5.

This fixes several SonarQube issues for the rule: [String literals should not be duplicated](https://rules.sonarsource.com/java/RSPEC-1192) 