### PR TITLE
SonarQube - String Literals on the left on comparisons

### DIFF
--- a/src/main/java/com/antstreaming/rtsp/RtspConnection.java
+++ b/src/main/java/com/antstreaming/rtsp/RtspConnection.java
@@ -506,7 +506,7 @@ public class RtspConnection  extends RTMPMinaConnection implements IMuxerListene
 		clientPort[streamId] = rtspTransport.getClientPort();
 		mode = rtspTransport.getMode();
 
-		if (mode != null && mode.equals("record")) {
+		if ("record".equals(mode)) {
 			//TODO check the url and do this operation according to the control parameter in the sdp
 
 			int portNo = PORT_NUMBER.getAndAdd(2);

--- a/src/main/java/io/antmedia/AntMediaApplicationAdapter.java
+++ b/src/main/java/io/antmedia/AntMediaApplicationAdapter.java
@@ -288,7 +288,7 @@ public class AntMediaApplicationAdapter extends MultiThreadedApplicationAdapter 
 	public void recreateEndpointsForSocialMedia(Broadcast broadcast, List<Endpoint> endPointList) {
 		for (Endpoint endpoint : endPointList) {
 
-			if (endpoint.type != null && !endpoint.type.equals("")) {
+			if (!"".equals(endpoint.type)) {
 				VideoServiceEndpoint videoServiceEndPoint = getVideoServiceEndPoint(endpoint.getEndpointServiceId());
 				if (videoServiceEndPoint != null) {
 					Endpoint newEndpoint;

--- a/src/main/java/io/antmedia/datastore/db/InMemoryDataStore.java
+++ b/src/main/java/io/antmedia/datastore/db/InMemoryDataStore.java
@@ -256,7 +256,7 @@ public class InMemoryDataStore extends DataStore {
 
 		for (Broadcast broadcast : values) 
 		{
-			if(broadcast.getType().equals("ipCamera")) 
+			if("ipCamera".equals(broadcast.getType())) 
 			{
 				if (t < offset) {
 					t++;
@@ -383,7 +383,7 @@ public class InMemoryDataStore extends DataStore {
 				String fileExtension = FilenameUtils.getExtension(file.getName());
 
 				if (file.isFile() && 
-						(fileExtension.equals("mp4") || fileExtension.equals("flv") || fileExtension.equals("mkv"))) 
+						("mp4".equals(fileExtension) || "flv".equals(fileExtension) || "mkv".equals(fileExtension))) 
 				{
 					long fileSize = file.length();
 					long unixTime = System.currentTimeMillis();

--- a/src/main/java/io/antmedia/datastore/db/MapDBStore.java
+++ b/src/main/java/io/antmedia/datastore/db/MapDBStore.java
@@ -575,7 +575,7 @@ public class MapDBStore extends DataStore {
 					String fileExtension = FilenameUtils.getExtension(file.getName());
 
 					if (file.isFile() && 
-							(fileExtension.equals("mp4") || fileExtension.equals("flv") || fileExtension.equals("mkv"))) {
+							("mp4".equals(fileExtension) || "flv".equals(fileExtension) || "mkv".equals(fileExtension))) {
 
 						long fileSize = file.length();
 						long unixTime = System.currentTimeMillis();

--- a/src/main/java/io/antmedia/datastore/db/MongoStore.java
+++ b/src/main/java/io/antmedia/datastore/db/MongoStore.java
@@ -404,7 +404,7 @@ public class MongoStore extends DataStore {
 				String fileExtension = FilenameUtils.getExtension(file.getName());
 
 				if (file.isFile() &&
-						(fileExtension.equals("mp4") || fileExtension.equals("flv") || fileExtension.equals("mkv"))) {
+						("mp4".equals(fileExtension) || "flv".equals(fileExtension) || "mkv".equals(fileExtension))) {
 
 					long fileSize = file.length();
 					long unixTime = System.currentTimeMillis();

--- a/src/main/java/io/antmedia/filter/HlsStatisticsFilter.java
+++ b/src/main/java/io/antmedia/filter/HlsStatisticsFilter.java
@@ -37,7 +37,7 @@ public class HlsStatisticsFilter implements javax.servlet.Filter {
 		HttpServletRequest httpRequest =(HttpServletRequest)request;
 
 		String method = httpRequest.getMethod();
-		if (method.equals("GET")) {
+		if ("GET".equals(method)) {
 			//only accept GET methods
 			String sessionId = httpRequest.getSession().getId();
 

--- a/src/main/java/io/antmedia/filter/TokenFilterManager.java
+++ b/src/main/java/io/antmedia/filter/TokenFilterManager.java
@@ -54,7 +54,7 @@ public class TokenFilterManager implements javax.servlet.Filter   {
 				,httpRequest.getRequestURI(), tokenId, sessionId, streamId);
 
 
-		if (method.equals("GET")) {
+		if ("GET".equals(method)) {
 			if(getAppSettings().isTokenControlEnabled()) {
 
 				result = getTokenService().checkToken(tokenId, streamId, sessionId, Token.PLAY_TOKEN);

--- a/src/main/java/io/antmedia/ipcamera/OnvifCamera.java
+++ b/src/main/java/io/antmedia/ipcamera/OnvifCamera.java
@@ -292,7 +292,7 @@ public class OnvifCamera implements IOnvifCamera {
 	public boolean isFocusModeAuto() {
 		ImagingSettings20 image_set = nvt.getImaging().getImagingSettings(profileToken);
 		FocusConfiguration20 focus = image_set.getFocus();
-		return focus.getAutoFocusMode().value().equals("AUTO");
+		return "AUTO".equals(focus.getAutoFocusMode().value());
 	}
 
 	@Override

--- a/src/main/java/io/antmedia/rest/BroadcastRestService.java
+++ b/src/main/java/io/antmedia/rest/BroadcastRestService.java
@@ -1589,7 +1589,7 @@ public class BroadcastRestService extends RestServiceBase{
 		String fileExtension = FilenameUtils.getExtension(fileName);
 		try {
 
-			if (fileExtension.equals("mp4")) {
+			if ("mp4".equals(fileExtension)) {
 
 
 				File streamsDirectory = new File(

--- a/src/main/java/io/antmedia/social/endpoint/PeriscopeEndpoint.java
+++ b/src/main/java/io/antmedia/social/endpoint/PeriscopeEndpoint.java
@@ -177,7 +177,7 @@ public class PeriscopeEndpoint extends VideoServiceEndpoint {
 		logger.warn("State: {}" , checkDeviceCode.state);
 
 		boolean result = false;
-		if ( checkDeviceCode.state.equals("associated")) {
+		if ( "associated".equals(checkDeviceCode.state)) {
 			init("", checkDeviceCode.access_token, checkDeviceCode.refresh_token, (long)checkDeviceCode.expires_in, checkDeviceCode.token_type, System.currentTimeMillis());
 			String accountName = "";
 			String accountId = "";
@@ -306,7 +306,7 @@ public class PeriscopeEndpoint extends VideoServiceEndpoint {
 	public String getBroadcast(Endpoint endpoint) throws Exception {
 		Broadcast broadcast = broadcastEndpoint.getBroadcast(endpoint.getBroadcastId());
 
-		return broadcast.state.equals("running") ? BroadcastStatus.LIVE_NOW : BroadcastStatus.UNPUBLISHED;
+		return "running".equals(broadcast.state) ? BroadcastStatus.LIVE_NOW : BroadcastStatus.UNPUBLISHED;
 	}
 
 

--- a/src/main/java/io/antmedia/websocket/WebSocketCommunityHandler.java
+++ b/src/main/java/io/antmedia/websocket/WebSocketCommunityHandler.java
@@ -161,7 +161,7 @@ public abstract class WebSocketCommunityHandler {
 	private void setRemoteDescription(RTMPAdaptor connectionContext, String typeString, String sdpDescription, String streamId) {
 		if (connectionContext != null) {
 			SessionDescription.Type type;
-			if (typeString.equals("offer")) {
+			if ("offer".equals(typeString)) {
 				type = Type.OFFER;
 				logger.info("received sdp type is offer {}", streamId);
 			}

--- a/src/main/java/org/red5/logging/W3CAppender.java
+++ b/src/main/java/org/red5/logging/W3CAppender.java
@@ -151,7 +151,7 @@ public class W3CAppender extends FileAppender<LoggingEvent> {
         //app-start                 application                         
         //app-stop                  application    
         //filter based on event type - asterik allows all events
-        if (!events.equals("*")) {
+        if (!"*".equals(events)) {
             if (!eventsList.contains(elements.get("x-event"))) {
                 elements.clear();
                 elements = null;

--- a/src/main/java/org/red5/server/scope/WebScope.java
+++ b/src/main/java/org/red5/server/scope/WebScope.java
@@ -217,7 +217,7 @@ public class WebScope extends Scope implements ServletContextAware, WebScopeMXBe
         hostnames = virtualHosts.split(",");
         for (int i = 0; i < hostnames.length; i++) {
             hostnames[i] = hostnames[i].trim();
-            if (hostnames[i].equals("*")) {
+            if ("*".equals(hostnames[i])) {
                 hostnames[i] = "";
             }
         }

--- a/src/main/java/org/red5/server/statistics/StatisticsService.java
+++ b/src/main/java/org/red5/server/statistics/StatisticsService.java
@@ -56,7 +56,7 @@ public class StatisticsService implements IStatisticsService {
 
     private IScope getScope(String path) throws ScopeNotFoundException {
         IScope scope;
-        if (path != null && !path.equals("")) {
+        if (!"".equals(path)) {
             scope = ScopeUtils.resolveScope(globalScope, path);
         } else {
             scope = globalScope;


### PR DESCRIPTION
Transforming from `someString.equals("string")`  to `"string".equals(someString)`. This avoids checking for `null` and also prevents `NullPointerException` being thrown.

These fixes multiple SonarQube violations of the rule: [Strings literals should be placed on the left side when checking for equality](https://rules.sonarsource.com/java/RSPEC-1132)