### PR TITLE
SonarQube - Optimizing String.lastIndexOf() for single char

### DIFF
--- a/src/main/java/com/antstreaming/rtsp/RtspConnection.java
+++ b/src/main/java/com/antstreaming/rtsp/RtspConnection.java
@@ -466,9 +466,9 @@ public class RtspConnection  extends RTMPMinaConnection implements IMuxerListene
 
 	private String getStreamName(String path) {
 		String streamName = null;
-		int lastIndexOf = path.lastIndexOf("/");
+		int lastIndexOf = path.lastIndexOf('/');
 		if (lastIndexOf != -1) {
-			streamName = path.substring(path.lastIndexOf("/") + 1);
+			streamName = path.substring(path.lastIndexOf('/') + 1);
 		}
 		return streamName;
 	}


### PR DESCRIPTION
Replacing `String.lastIndexOf("/")` with `String.lastIndexOf('/')` which can be more performant.

This fixes SonarQube violations of the rule: [String function use should be optimized for single characters](https://rules.sonarsource.com/java/RSPEC-3027)