### PR TITLE
Fix: Shutdown issue and social media polling

### DIFF
--- a/src/main/java/io/antmedia/statistic/StatsCollector.java
+++ b/src/main/java/io/antmedia/statistic/StatsCollector.java
@@ -660,10 +660,11 @@ public class StatsCollector implements IStatsCollector, ApplicationContextAware 
 
 			@Override
 			public void run() {
-				AMSShutdownManager.getInstance().notifyShutdown();
+				
 				if(logger != null) {
 					logger.info("Shutting down just a sec");
 				}
+				AMSShutdownManager.getInstance().notifyShutdown();
 				getGoogleAnalytic(implementationVersion, type).screenView()
 				.clientId(Launcher.getInstanceId())
 				.sessionControl("end")


### PR DESCRIPTION
Shutdown issue: Server does not stop while there is a live rtmp stream
Polling issue: It recursively adds periodic tasks for polling and social
media service denies request




