### PR TITLE
Remove ip address validation

### DIFF
--- a/src/main/java/io/antmedia/rest/RestServiceBase.java
+++ b/src/main/java/io/antmedia/rest/RestServiceBase.java
@@ -1022,9 +1022,6 @@ public abstract class RestServiceBase {
 				ipAddr = ipAddrParts[0];
 
 			}
-			if(ipAddr.split("\\.").length == 4 && !validateIPaddress(ipAddr)){
-				streamUrlControl = false;
-			}
 		}
 		return streamUrlControl;
 	}

--- a/src/test/java/io/antmedia/test/db/DBStoresUnitTest.java
+++ b/src/test/java/io/antmedia/test/db/DBStoresUnitTest.java
@@ -105,7 +105,6 @@ public class DBStoresUnitTest {
 
 	@Test
 	public void testMemoryDataStore() {
-
 		DataStore dataStore = new InMemoryDataStore("testdb");
 		testBugGetExternalStreamsList(dataStore);
 		testGetPagination(dataStore);


### PR DESCRIPTION
When you enter a nested subdomain such as sub1.sub2.sub3.com while adding a stream source, it cannot pass the check stream url validation because there is a ip address validation. This validation assumes that when there are 4 dots, it is an ip address. However, it might be also a nested subdomain. As a solution, this ip address validation is removed.