### PR TITLE
Feature/rtmp send specific resolution

### DIFF
--- a/src/main/java/io/antmedia/datastore/db/MapDBStore.java
+++ b/src/main/java/io/antmedia/datastore/db/MapDBStore.java
@@ -68,8 +68,10 @@ public class MapDBStore extends DataStore {
 		db = DBMaker
 				.fileDB(dbName)
 				.fileMmapEnableIfSupported()
-				//.transactionEnable() we disable this because under load, it causes exception.
+				/*.transactionEnable() we disable this because under load, it causes exception.
 					//In addition, we already commit and synch methods. So it seems that we don't need this one
+				*/
+				.checksumHeaderBypass()
 				.make();
 
 		

--- a/src/main/java/io/antmedia/muxer/MuxAdaptor.java
+++ b/src/main/java/io/antmedia/muxer/MuxAdaptor.java
@@ -1668,7 +1668,7 @@ public class MuxAdaptor implements IRecordingListener, IEndpointStatusListener {
 		return rtmpMuxer;
 	}
 
-	public boolean stopRtmpStreaming(String rtmpUrl)
+	public boolean stopRtmpStreaming(String rtmpUrl, int resolution)
 	{
 		RtmpMuxer rtmpMuxer = getRtmpMuxer(rtmpUrl);
 		boolean result = false;

--- a/src/main/java/io/antmedia/muxer/MuxAdaptor.java
+++ b/src/main/java/io/antmedia/muxer/MuxAdaptor.java
@@ -1583,7 +1583,7 @@ public class MuxAdaptor implements IRecordingListener, IEndpointStatusListener {
 	}
 
 
-	public boolean startRtmpStreaming(String rtmpUrl)
+	public boolean startRtmpStreaming(String rtmpUrl, int resolution)
 	{
 		if (!isRecording) {
 			logger.warn("Start rtmp streaming return false for stream:{} because stream is being prepared", streamId);

--- a/src/main/java/io/antmedia/rest/BroadcastRestService.java
+++ b/src/main/java/io/antmedia/rest/BroadcastRestService.java
@@ -387,7 +387,7 @@ public class BroadcastRestService extends RestServiceBase{
 			String status = getDataStore().get(id).getStatus();
 			if (status.equals(IAntMediaStreamHandler.BROADCAST_STATUS_BROADCASTING)) 
 			{
-				boolean started = getMuxAdaptor(id).stopRtmpStreaming(rtmpUrl);
+				boolean started = getMuxAdaptor(id).stopRtmpStreaming(rtmpUrl, 0);
 				result.setSuccess(started);
 			}
 		}
@@ -407,8 +407,9 @@ public class BroadcastRestService extends RestServiceBase{
 	@Path("/{id}/rtmp-endpoint")
 	@Produces(MediaType.APPLICATION_JSON)
 	public Result removeEndpointV2(@ApiParam(value = "Broadcast id", required = true) @PathParam("id") String id, 
-			@ApiParam(value = "RTMP url of the endpoint that will be stopped.", required = true) @QueryParam("endpointServiceId") String endpointServiceId
-			){
+			@ApiParam(value = "RTMP url of the endpoint that will be stopped.", required = true) @QueryParam("endpointServiceId") String endpointServiceId, 
+								   @ApiParam(value = "Resolution specifier if endpoint has been added with resolution. Only applicable if user added RTMP endpoint with a resolution speficier. Otherwise won't work and won't remove the endpoint.", required = true) 
+									   @QueryParam("resolution") int resolution){
 		
 		//Get rtmpURL with broadcast
 		String rtmpUrl = null;
@@ -427,7 +428,7 @@ public class BroadcastRestService extends RestServiceBase{
 		
 		if (result.isSuccess()) 
 		{
-			result = processRTMPEndpoint(result, broadcast, rtmpUrl, false, 0);
+			result = processRTMPEndpoint(result, broadcast, rtmpUrl, false, resolution);
 		}
 		else if (logger.isErrorEnabled()) {	
 			logger.error("Rtmp endpoint({}) was not removed from the stream: {}", rtmpUrl != null ? rtmpUrl.replaceAll(REPLACE_CHARS, "_") : null , id.replaceAll(REPLACE_CHARS, "_"));

--- a/src/main/java/io/antmedia/rest/BroadcastRestService.java
+++ b/src/main/java/io/antmedia/rest/BroadcastRestService.java
@@ -320,7 +320,7 @@ public class BroadcastRestService extends RestServiceBase{
 			String status = getDataStore().get(id).getStatus();
 			if (status.equals(IAntMediaStreamHandler.BROADCAST_STATUS_BROADCASTING)) 
 			{
-				boolean started = getMuxAdaptor(id).startRtmpStreaming(rtmpUrl);
+				boolean started = getMuxAdaptor(id).startRtmpStreaming(rtmpUrl, 0);
 				result.setSuccess(started);
 			}
 		}
@@ -333,13 +333,14 @@ public class BroadcastRestService extends RestServiceBase{
 		return result;
 	}
 	
-	@ApiOperation(value = "Add a third pary rtmp end point to the stream. It supports adding after broadcast is started ", notes = "", response = Result.class)
+	@ApiOperation(value = "Adds a third party rtmp end point to the stream. It supports adding after broadcast is started. Resolution can be specified to send a specific adaptive resolution", notes = "", response = Result.class)
 	@POST
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Path("/{id}/rtmp-endpoint")
 	@Produces(MediaType.APPLICATION_JSON)
 	public Result addEndpointV3(@ApiParam(value = "Broadcast id", required = true) @PathParam("id") String id,
-			@ApiParam(value = "RTMP url of the endpoint that stream will be republished. If required, please encode the URL", required = true) Endpoint endpoint) {
+			@ApiParam(value = "RTMP url of the endpoint that stream will be republished. If required, please encode the URL", required = true) Endpoint endpoint,
+								@ApiParam(value = "Resolution of the broadcast that is wanted to send to the RTMP endpoint. Only applicable if there is at least an adaptive resolution is available.", required = false) @QueryParam("resolution") int resolution) {
 		
 		String rtmpUrl = null;
 		Result result = new Result(false);
@@ -351,7 +352,7 @@ public class BroadcastRestService extends RestServiceBase{
 		
 		if (result.isSuccess()) 
 		{
-			result = processRTMPEndpoint(result,  getDataStore().get(id), rtmpUrl, true);
+			result = processRTMPEndpoint(result,  getDataStore().get(id), rtmpUrl, true, resolution);
 		}
 		else {
 			result.setMessage("Rtmp endpoint is not added to datastore");
@@ -416,7 +417,7 @@ public class BroadcastRestService extends RestServiceBase{
 		
 		if (result.isSuccess()) 
 		{
-			result = processRTMPEndpoint(result, broadcast, rtmpUrl, false);
+			result = processRTMPEndpoint(result, broadcast, rtmpUrl, false, 0);
 		}
 		else if (logger.isErrorEnabled()) {	
 			logger.error("Rtmp endpoint({}) was not removed from the stream: {}", rtmpUrl != null ? rtmpUrl.replaceAll(REPLACE_CHARS, "_") : null , id.replaceAll(REPLACE_CHARS, "_"));

--- a/src/main/java/io/antmedia/rest/RestServiceBase.java
+++ b/src/main/java/io/antmedia/rest/RestServiceBase.java
@@ -692,7 +692,7 @@ public abstract class RestServiceBase {
 						started = getMuxAdaptor(broadcast.getStreamId()).startRtmpStreaming(rtmpUrl, resolution);
 					}
 					else {
-						started = getMuxAdaptor(broadcast.getStreamId()).stopRtmpStreaming(rtmpUrl);
+						started = getMuxAdaptor(broadcast.getStreamId()).stopRtmpStreaming(rtmpUrl, resolution);
 					}
 					result.setSuccess(started);
 				}

--- a/src/main/java/io/antmedia/rest/RestServiceBase.java
+++ b/src/main/java/io/antmedia/rest/RestServiceBase.java
@@ -675,7 +675,7 @@ public abstract class RestServiceBase {
 
 	}
 
-	public Result processRTMPEndpoint(Result result, Broadcast broadcast, String rtmpUrl, boolean addEndpoint) {
+	public Result processRTMPEndpoint(Result result, Broadcast broadcast, String rtmpUrl, boolean addEndpoint, int resolution) {
 		if (broadcast != null) 
 		{
 			boolean isCluster = getAppContext().containsBean(IClusterNotifier.BEAN_NAME);
@@ -685,7 +685,7 @@ public abstract class RestServiceBase {
 			{
 				if((broadcast.getOriginAdress().equals(getServerSettings().getHostAddress()) || !isCluster)) {
 					if(addEndpoint) {
-						started = getMuxAdaptor(broadcast.getStreamId()).startRtmpStreaming(rtmpUrl);
+						started = getMuxAdaptor(broadcast.getStreamId()).startRtmpStreaming(rtmpUrl, resolution);
 					}
 					else {
 						started = getMuxAdaptor(broadcast.getStreamId()).stopRtmpStreaming(rtmpUrl);

--- a/src/test/java/io/antmedia/test/rest/BroadcastRestServiceV2UnitTest.java
+++ b/src/test/java/io/antmedia/test/rest/BroadcastRestServiceV2UnitTest.java
@@ -1094,7 +1094,7 @@ public class BroadcastRestServiceV2UnitTest {
 			
 			Mockito.doReturn(muxAdaptor).when(restServiceSpy).getMuxAdaptor(broadcast.getStreamId());
 			
-			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), 0)).thenReturn(true);
+			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), Mockito.eq(0))).thenReturn(true);
 			
 			Endpoint endpoint3 = new Endpoint();
 			endpoint3.setRtmpUrl("rtmp://test.endpoint.url/any_stream_test");
@@ -1113,7 +1113,7 @@ public class BroadcastRestServiceV2UnitTest {
 			
 			Mockito.doReturn(muxAdaptor).when(restServiceSpy).getMuxAdaptor(broadcast.getStreamId());
 			
-			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), 0)).thenReturn(true);
+			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), Mockito.eq(0))).thenReturn(true);
 			
 			Endpoint endpoint3 = new Endpoint();
 			//This is already in the endpoints list, so it won't be added.
@@ -1127,7 +1127,7 @@ public class BroadcastRestServiceV2UnitTest {
 			//This is not included in the endpoints list, so it should be true.
 			endpoint3true.setRtmpUrl("rtmp://test.endpoint.url/any_other_stream_test");
 			
-			assertTrue(restServiceSpy.addEndpointV3(streamId, endpoint3true).isSuccess());
+			assertTrue(restServiceSpy.addEndpointV3(streamId, endpoint3true, 0).isSuccess());
 		}
 		
 		// enable Cluster mode with same origin and broadcast
@@ -1142,7 +1142,7 @@ public class BroadcastRestServiceV2UnitTest {
 			
 			Mockito.doReturn(muxAdaptor).when(restServiceSpy).getMuxAdaptor(broadcast.getStreamId());
 			
-			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), 0)).thenReturn(true);
+			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), Mockito.eq(0))).thenReturn(true);
 			
 			Endpoint endpoint4 = new Endpoint();
 			//This is already in the endpoints list, so it won't be added.
@@ -1156,7 +1156,7 @@ public class BroadcastRestServiceV2UnitTest {
 			//This is not included in the endpoints list, so it should be true.
 			endpoint4true.setRtmpUrl("rtmp://test.endpoint.url/any_stream_test2");
 			
-			assertTrue(restServiceSpy.addEndpointV3(streamId, endpoint4true).isSuccess());
+			assertTrue(restServiceSpy.addEndpointV3(streamId, endpoint4true, 0).isSuccess());
 		}
 		
 		// enable Cluster mode with different origin and broadcast
@@ -1170,7 +1170,7 @@ public class BroadcastRestServiceV2UnitTest {
 			
 			Mockito.doReturn(muxAdaptor).when(restServiceSpy).getMuxAdaptor(broadcast.getStreamId());
 			
-			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), 0)).thenReturn(true);
+			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), Mockito.eq(0))).thenReturn(true);
 			
 			Endpoint endpoint5 = new Endpoint();
 			endpoint5.setRtmpUrl("rtmp://test.endpoint.url/any_stream_test");

--- a/src/test/java/io/antmedia/test/rest/BroadcastRestServiceV2UnitTest.java
+++ b/src/test/java/io/antmedia/test/rest/BroadcastRestServiceV2UnitTest.java
@@ -974,7 +974,7 @@ public class BroadcastRestServiceV2UnitTest {
 			Endpoint endpoint6 = new Endpoint();
 			endpoint6.setRtmpUrl("rtmp://test.endpoint.url/any_stream_test");
 			
-			assertFalse(restServiceReal.addEndpointV3("Not_regsitered_s, 0tream_id", endpoint6, 0).isSuccess());
+			assertFalse(restServiceReal.addEndpointV3("Not_regsitered_stream_id", endpoint6, 0).isSuccess());
 		}
 
 	}

--- a/src/test/java/io/antmedia/test/rest/BroadcastRestServiceV2UnitTest.java
+++ b/src/test/java/io/antmedia/test/rest/BroadcastRestServiceV2UnitTest.java
@@ -1022,7 +1022,7 @@ public class BroadcastRestServiceV2UnitTest {
 			
 			Mockito.doReturn(muxAdaptor).when(restServiceSpy).getMuxAdaptor(broadcast.getStreamId());
 			
-			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), 0)).thenReturn(true);
+			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), Mockito.eq(0))).thenReturn(true);
 			
 			store.updateStatus(broadcast.getStreamId(), AntMediaApplicationAdapter.BROADCAST_STATUS_BROADCASTING);
 			assertTrue(restServiceSpy.addEndpointV2(streamId, "rtmp://test.endpoint.url/any_stream_test").isSuccess());

--- a/src/test/java/io/antmedia/test/rest/BroadcastRestServiceV2UnitTest.java
+++ b/src/test/java/io/antmedia/test/rest/BroadcastRestServiceV2UnitTest.java
@@ -865,7 +865,7 @@ public class BroadcastRestServiceV2UnitTest {
 			Endpoint endpoint = new Endpoint();
 			endpoint.setRtmpUrl(endpointURL);
 			
-			Result result = restServiceReal.addEndpointV3(streamId, endpoint);
+			Result result = restServiceReal.addEndpointV3(streamId, endpoint, 0);
 			assertTrue(result.isSuccess());
 			
 			assertEquals(1, store.get(streamId).getEndPointList().size());
@@ -887,7 +887,7 @@ public class BroadcastRestServiceV2UnitTest {
 			Endpoint endpoint = new Endpoint();
 			endpoint.setRtmpUrl(endpointURL);
 			
-			Result result = restServiceReal.addEndpointV3(streamId, endpoint);
+			Result result = restServiceReal.addEndpointV3(streamId, endpoint, 0);
 			assertTrue(result.isSuccess());
 			
 			assertEquals(1, store.get(streamId).getEndPointList().size());
@@ -921,7 +921,7 @@ public class BroadcastRestServiceV2UnitTest {
 			Endpoint endpoint = new Endpoint();
 			endpoint.setRtmpUrl(endpointURL);
 
-			Result result = restServiceSpy.addEndpointV3(streamId, endpoint);
+			Result result = restServiceSpy.addEndpointV3(streamId, endpoint, 0);
 			assertTrue(result.isSuccess());
 			
 			assertEquals(1, store.get(streamId).getEndPointList().size());
@@ -952,7 +952,7 @@ public class BroadcastRestServiceV2UnitTest {
 			Endpoint endpoint = new Endpoint();
 			endpoint.setRtmpUrl(endpointURL);
 
-			Result result = restServiceSpy.addEndpointV3(streamId, endpoint);
+			Result result = restServiceSpy.addEndpointV3(streamId, endpoint, 0);
 			assertTrue(result.isSuccess());
 					
 			assertEquals(1, store.get(streamId).getEndPointList().size());
@@ -974,7 +974,7 @@ public class BroadcastRestServiceV2UnitTest {
 			Endpoint endpoint6 = new Endpoint();
 			endpoint6.setRtmpUrl("rtmp://test.endpoint.url/any_stream_test");
 			
-			assertFalse(restServiceReal.addEndpointV3("Not_regsitered_stream_id", endpoint6).isSuccess());
+			assertFalse(restServiceReal.addEndpointV3("Not_regsitered_s, 0tream_id", endpoint6, 0).isSuccess());
 		}
 
 	}
@@ -1023,7 +1023,7 @@ public class BroadcastRestServiceV2UnitTest {
 			
 			Mockito.doReturn(muxAdaptor).when(restServiceSpy).getMuxAdaptor(broadcast.getStreamId());
 			
-			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString())).thenReturn(true);
+			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), 0)).thenReturn(true);
 			
 			store.updateStatus(broadcast.getStreamId(), AntMediaApplicationAdapter.BROADCAST_STATUS_BROADCASTING);
 			assertTrue(restServiceSpy.addEndpointV2(streamId, "rtmp://test.endpoint.url/any_stream_test").isSuccess());
@@ -1070,14 +1070,14 @@ public class BroadcastRestServiceV2UnitTest {
 		Endpoint endpoint = new Endpoint();
 		endpoint.setRtmpUrl(endpointURL);
 
-		Result result = restServiceReal.addEndpointV3(streamId, endpoint);
+		Result result = restServiceReal.addEndpointV3(streamId, endpoint, 0);
 		assertTrue(result.isSuccess());
 		assertNotNull(result.getDataId());
 		String endpointServiceId = result.getDataId();
 		
 		endpoint = null;
 		
-		assertFalse(restServiceReal.addEndpointV3(streamId, endpoint).isSuccess());
+		assertFalse(restServiceReal.addEndpointV3(streamId, endpoint, 0).isSuccess());
 
 		Broadcast broadcast2 = (Broadcast) restServiceReal.getBroadcast(streamId).getEntity();
 		assertEquals(broadcast.getStreamId(), broadcast2.getStreamId());
@@ -1095,13 +1095,13 @@ public class BroadcastRestServiceV2UnitTest {
 			
 			Mockito.doReturn(muxAdaptor).when(restServiceSpy).getMuxAdaptor(broadcast.getStreamId());
 			
-			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString())).thenReturn(true);
+			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), 0)).thenReturn(true);
 			
 			Endpoint endpoint3 = new Endpoint();
 			endpoint3.setRtmpUrl("rtmp://test.endpoint.url/any_stream_test");
 			
 			store.updateStatus(broadcast.getStreamId(), AntMediaApplicationAdapter.BROADCAST_STATUS_BROADCASTING);
-			assertTrue(restServiceSpy.addEndpointV3(streamId, endpoint3).isSuccess());
+			assertTrue(restServiceSpy.addEndpointV3(streamId, endpoint3, 0).isSuccess());
 		}
 		
 		// Standallone Add RTMP Endpoint with different origin and broadcast
@@ -1114,13 +1114,13 @@ public class BroadcastRestServiceV2UnitTest {
 			
 			Mockito.doReturn(muxAdaptor).when(restServiceSpy).getMuxAdaptor(broadcast.getStreamId());
 			
-			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString())).thenReturn(true);
+			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), 0)).thenReturn(true);
 			
 			Endpoint endpoint3 = new Endpoint();
 			endpoint3.setRtmpUrl("rtmp://test.endpoint.url/any_stream_test");
 			
 			store.updateStatus(broadcast.getStreamId(), AntMediaApplicationAdapter.BROADCAST_STATUS_BROADCASTING);
-			assertTrue(restServiceSpy.addEndpointV3(streamId, endpoint3).isSuccess());
+			assertTrue(restServiceSpy.addEndpointV3(streamId, endpoint3, 0).isSuccess());
 		}
 		
 		// enable Cluster mode with same origin and broadcast
@@ -1135,13 +1135,13 @@ public class BroadcastRestServiceV2UnitTest {
 			
 			Mockito.doReturn(muxAdaptor).when(restServiceSpy).getMuxAdaptor(broadcast.getStreamId());
 			
-			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString())).thenReturn(true);
+			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), 0)).thenReturn(true);
 			
 			Endpoint endpoint4 = new Endpoint();
 			endpoint4.setRtmpUrl("rtmp://test.endpoint.url/any_stream_test");
 			
 			store.updateStatus(broadcast.getStreamId(), AntMediaApplicationAdapter.BROADCAST_STATUS_BROADCASTING);
-			assertTrue(restServiceSpy.addEndpointV3(streamId, endpoint4).isSuccess());
+			assertTrue(restServiceSpy.addEndpointV3(streamId, endpoint4, 0).isSuccess());
 			
 		}
 		
@@ -1156,13 +1156,13 @@ public class BroadcastRestServiceV2UnitTest {
 			
 			Mockito.doReturn(muxAdaptor).when(restServiceSpy).getMuxAdaptor(broadcast.getStreamId());
 			
-			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString())).thenReturn(true);
+			Mockito.when(muxAdaptor.startRtmpStreaming(Mockito.anyString(), 0)).thenReturn(true);
 			
 			Endpoint endpoint5 = new Endpoint();
 			endpoint5.setRtmpUrl("rtmp://test.endpoint.url/any_stream_test");
 			
 			store.updateStatus(broadcast.getStreamId(), AntMediaApplicationAdapter.BROADCAST_STATUS_BROADCASTING);
-			assertFalse(restServiceSpy.addEndpointV3(streamId, endpoint5).isSuccess());
+			assertFalse(restServiceSpy.addEndpointV3(streamId, endpoint5, 0).isSuccess());
 			
 		}
 		
@@ -1170,7 +1170,7 @@ public class BroadcastRestServiceV2UnitTest {
 			Endpoint endpoint6 = new Endpoint();
 			endpoint6.setRtmpUrl("rtmp://test.endpoint.url/any_stream_test");
 			
-			assertFalse(restServiceReal.addEndpointV3("Not_regsitered_stream_id", endpoint6).isSuccess());
+			assertFalse(restServiceReal.addEndpointV3("Not_regsitered_stream_id", endpoint6, 0).isSuccess());
 		}
 
 	}

--- a/src/test/java/io/antmedia/test/rest/BroadcastRestServiceV2UnitTest.java
+++ b/src/test/java/io/antmedia/test/rest/BroadcastRestServiceV2UnitTest.java
@@ -806,7 +806,7 @@ public class BroadcastRestServiceV2UnitTest {
 			
 			Mockito.doReturn(muxAdaptor).when(restServiceSpy).getMuxAdaptor(streamId);
 			
-			Mockito.when(muxAdaptor.stopRtmpStreaming(Mockito.anyString())).thenReturn(true);
+			Mockito.when(muxAdaptor.stopRtmpStreaming(Mockito.anyString(), Mockito.eq(0))).thenReturn(true);
 			
 			String endpointURL = "rtmp://test.endpoint.url/test";
 			Result result = restServiceSpy.addEndpointV2(streamId, endpointURL);
@@ -851,7 +851,7 @@ public class BroadcastRestServiceV2UnitTest {
 		when(scope.getName()).thenReturn(scopeName);
 		restServiceReal.setScope(scope);
 		
-		assertFalse(restServiceReal.removeEndpointV2("any_stream_not_registered", "rtmp://test.endpoint.url/server_test").isSuccess());
+		assertFalse(restServiceReal.removeEndpointV2("any_stream_not_registered", "rtmp://test.endpoint.url/server_test", 0).isSuccess());
 		String streamId = null;
 		// Standallone Remove RTMP Endpoint with same origin and broadcast
 		{			
@@ -872,7 +872,7 @@ public class BroadcastRestServiceV2UnitTest {
 			serverHostAddress = "127.0.1.1";
 			when(serverSettings.getHostAddress()).thenReturn(serverHostAddress);
 			
-			assertTrue(restServiceReal.removeEndpointV2(streamId, store.get(streamId).getEndPointList().get(0).getEndpointServiceId()).isSuccess());
+			assertTrue(restServiceReal.removeEndpointV2(streamId, store.get(streamId).getEndPointList().get(0).getEndpointServiceId(), 0).isSuccess());
 		}
 		
 		// Standallone Remove RTMP Endpoint with different origin and broadcast
@@ -894,7 +894,7 @@ public class BroadcastRestServiceV2UnitTest {
 			serverHostAddress = "55.55.55.55";
 			when(serverSettings.getHostAddress()).thenReturn(serverHostAddress);
 			
-			assertTrue(restServiceReal.removeEndpointV2(streamId, store.get(streamId).getEndPointList().get(0).getEndpointServiceId()).isSuccess());
+			assertTrue(restServiceReal.removeEndpointV2(streamId, store.get(streamId).getEndPointList().get(0).getEndpointServiceId(), 0).isSuccess());
 		}
 		
 		// enable Cluster mode with same origin and broadcast
@@ -912,7 +912,7 @@ public class BroadcastRestServiceV2UnitTest {
 			
 			Mockito.doReturn(muxAdaptor).when(restServiceSpy).getMuxAdaptor(streamId);
 			
-			Mockito.when(muxAdaptor.stopRtmpStreaming(Mockito.anyString())).thenReturn(true);
+			Mockito.when(muxAdaptor.stopRtmpStreaming(Mockito.anyString(), Mockito.eq(0))).thenReturn(true);
 			
 			
 			String endpointURL = "rtmp://test.endpoint.url/test";
@@ -931,7 +931,7 @@ public class BroadcastRestServiceV2UnitTest {
 			serverHostAddress = "127.0.1.1";
 			when(serverSettings.getHostAddress()).thenReturn(serverHostAddress);
 			
-			assertTrue(restServiceSpy.removeEndpointV2(streamId, store.get(streamId).getEndPointList().get(0).getEndpointServiceId()).isSuccess());
+			assertTrue(restServiceSpy.removeEndpointV2(streamId, store.get(streamId).getEndPointList().get(0).getEndpointServiceId(), 0).isSuccess());
 		}
 		
 		// enable Cluster mode with different origin and broadcast
@@ -945,7 +945,7 @@ public class BroadcastRestServiceV2UnitTest {
 			
 			Mockito.doReturn(muxAdaptor).when(restServiceSpy).getMuxAdaptor(streamId);
 			
-			Mockito.when(muxAdaptor.stopRtmpStreaming(Mockito.anyString())).thenReturn(true);
+			Mockito.when(muxAdaptor.stopRtmpStreaming(Mockito.anyString(), Mockito.eq(0))).thenReturn(true);
 			String endpointURL = "rtmp://test.endpoint.url/test";
 					
 			Endpoint endpoint = new Endpoint();
@@ -962,7 +962,7 @@ public class BroadcastRestServiceV2UnitTest {
 			serverHostAddress = "55.55.55.55";
 			when(serverSettings.getHostAddress()).thenReturn(serverHostAddress);
 					
-			assertFalse(restServiceSpy.removeEndpointV2(streamId, store.get(streamId).getEndPointList().get(0).getEndpointServiceId()).isSuccess());
+			assertFalse(restServiceSpy.removeEndpointV2(streamId, store.get(streamId).getEndPointList().get(0).getEndpointServiceId(), 0).isSuccess());
 		}
 				
 		{


### PR DESCRIPTION
This PR fixes #3338
This PR adds ability to send adaptive stream resolutions to RTMP endpoint. Users can specify which resolution they want to send to the endpoint but that resolution should be available in the adaptive resolution list, otherwise it will return false.