### PR TITLE
check for +srv connection

### DIFF
--- a/src/main/java/io/antmedia/datastore/db/MongoStore.java
+++ b/src/main/java/io/antmedia/datastore/db/MongoStore.java
@@ -103,6 +103,10 @@ public class MongoStore extends DataStore {
 	}
 	
 	public static String getMongoConnectionUri(String host, String username, String password) {
+		//If it is DNS seed name, no need to check for username and password since it needs to be integrated to the given uri.
+		//Mongodb Atlas users will have such syntax and won't need to enter seperate username and password to the script since it is already in the uri.
+		if(host.indexOf("mongodb+srv") == 0)
+			return host;
 		String credential = "";
 		if(username != null && !username.isEmpty()) {
 			credential = username+":"+password+"@";


### PR DESCRIPTION
#3446 
With this change, mongodb atlas users can use its URI with +srv which DNS seed URI. Users don't need to enter username and password to change mode script since it needs to be with uri