### PR TITLE
Fix HLS muxing file deletion for more than 4 digit segment suffixes

### DIFF
--- a/src/main/java/io/antmedia/muxer/HLSMuxer.java
+++ b/src/main/java/io/antmedia/muxer/HLSMuxer.java
@@ -380,7 +380,7 @@ public class HLSMuxer extends Muxer  {
 			//SEGMENT_SUFFIX_TS is %04d.ts
 			//convert segmentFileName to regular expression
 			String segmentFileWithoutSuffixTS = segmentFilename.substring(segmentFilename.lastIndexOf("/")+1, segmentFilename.indexOf(SEGMENT_SUFFIX_TS));
-			String regularExpression = segmentFileWithoutSuffixTS + "[0-9]{4}\\.ts$";
+			String regularExpression = segmentFileWithoutSuffixTS + "[0-9]*\\.ts$";
 			File[] files = file.getParentFile().listFiles((dir, name) -> 
 			
 				//matches m3u8 file or ts segment file


### PR DESCRIPTION
FFMpeg will write over 4 digit segment suffixes even with the hls_segment_filename option specified for only 4 digits. HLS muxing needs to delete these files on exit.

https://github.com/ant-media/Ant-Media-Server/issues/4047