### PR TITLE
TunaDesk Remote Desktop Control Tool Changes

### DIFF
--- a/src/main/java/io/antmedia/websocket/WebSocketConstants.java
+++ b/src/main/java/io/antmedia/websocket/WebSocketConstants.java
@@ -506,5 +506,27 @@ public class WebSocketConstants {
 	 */
 	public static final String MAX_TRACK_COUNT = "maxTrackCount";
 
-	
+	public static final String CREATE_REMOTE_DESKTOP_CONTROL_SESSION= "createRdcSession";
+
+	public static final String REMOTE_DESKTOP_CONTROL_HOST_ID = "rdcHostId";
+
+	public static final String REMOTE_DESKTOP_CONTROL_SESSION_NAME = "rdcSessionName";
+
+	public static final String START_REMOTE_DESKTOP_CONTROL = "startRdc";
+
+	public static final String REMOTE_DESKTOP_CONTROL_CONTROLLER_SESSION_ID = "rdcControllerSessionId";
+
+	public static final String SET_REMOTE_DESKTOP_CONTROL_STREAM_ID = "setRdcStreamId";
+
+	public static final String REMOTE_DESKTOP_CONTROL_STREAM_ID = "rdcStreamId";
+
+	public static final String STOP_REMOTE_DESKTOP_CONTROL_CONTROLLING = "rdcStopControlling";
+
+	public static final String FINISH_REMOTE_DESKTOP_CONTROL = "rdcFinish";
+
+	public static final String CONTROLLER_STOPPED_REMOTE_DESKTOP_CONTROL = "rdcControllerStopped";
+
+	public static final String REMOTE_DESKTOP_CONTROL_SESSION_FINISHED = "rdcSessionFinished";
+
+
 }


### PR DESCRIPTION
https://github.com/ant-media/Ant-Media-Server/issues/4928

The changes required for TunaDesk, which is Ant Media's remote desktop control tool, are being introduced in this PR.
The modifications are limited to web socket message names as communication messages are managed on the enterprise end.

For the controller and host applications check this repo:
https://github.com/ant-media/TunaDesk