### PR TITLE
Revert "Change the default setting from 'true' to 'false' for sending audio levels through the data channel"

### DIFF
--- a/src/main/java/io/antmedia/AppSettings.java
+++ b/src/main/java/io/antmedia/AppSettings.java
@@ -2050,8 +2050,8 @@ public class AppSettings implements Serializable{
 	 * 
 	 * Ant Media Server sends audio level 5 times in a second
 	 */
-	@Value("${sendAudioLevelToViewers:false}")
-	private boolean sendAudioLevelToViewers = false;
+	@Value("${sendAudioLevelToViewers:true}")
+	private boolean sendAudioLevelToViewers = true;
 
 	public void setWriteStatsToDatastore(boolean writeStatsToDatastore) {
 		this.writeStatsToDatastore = writeStatsToDatastore;

--- a/src/test/java/io/antmedia/test/AppSettingsUnitTest.java
+++ b/src/test/java/io/antmedia/test/AppSettingsUnitTest.java
@@ -492,7 +492,7 @@ public class AppSettingsUnitTest extends AbstractJUnit4SpringContextTests {
 		assertEquals(150, appSettings.getAbrUpScaleRTTMs(), 0.0001);
 		assertNotNull(appSettings.getClusterCommunicationKey());
 		assertEquals(false, appSettings.isId3TagEnabled());
-		assertEquals(false, appSettings.isSendAudioLevelToViewers());
+		assertEquals(true, appSettings.isSendAudioLevelToViewers());
 		assertNull(appSettings.getTimeTokenSecretForPublish());
 		assertNull(appSettings.getTimeTokenSecretForPlay());
 		


### PR DESCRIPTION
Reverts ant-media/Ant-Media-Server#5974