### PR TITLE
Broadcast Level ABR Settings

### DIFF
--- a/src/main/java/io/antmedia/datastore/db/DataStore.java
+++ b/src/main/java/io/antmedia/datastore/db/DataStore.java
@@ -999,6 +999,7 @@ public abstract class DataStore {
 		broadcast.setSubTrackStreamIds(newBroadcast.getSubTrackStreamIds());
 		broadcast.setPlaylistLoopEnabled(newBroadcast.isPlaylistLoopEnabled());
 		broadcast.setAutoStartStopEnabled(newBroadcast.isAutoStartStopEnabled());
+		broadcast.setEncoderSettings(newBroadcast.getEncoderSettings());
 	}
 
 

--- a/src/main/java/io/antmedia/datastore/db/types/Broadcast.java
+++ b/src/main/java/io/antmedia/datastore/db/types/Broadcast.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import dev.morphia.utils.IndexType;
+import io.antmedia.EncoderSettings;
 import org.bson.types.ObjectId;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -15,6 +16,10 @@ import dev.morphia.annotations.Index;
 import dev.morphia.annotations.Indexes;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.springframework.beans.factory.annotation.Value;
+
+import static io.antmedia.AppSettings.encodersList2Str;
+import static io.antmedia.AppSettings.encodersStr2List;
 
 
 @ApiModel(value="Broadcast", description="The basic broadcast class")
@@ -199,6 +204,12 @@ public class Broadcast {
 	 */
 	@ApiModelProperty(value = "WebM muxing whether enabled or not for the stream, 1 means enabled, -1 means disabled, 0 means no settings for the stream")
 	private int webMEnabled = 0;
+
+	/**
+	 * Broadcast level ABR settings.
+	 */
+	@ApiModelProperty(value = "Encoder settings for broadcast level ABR")
+	private List<EncoderSettings> encoderSettings;
 
 	@Entity
 	public static class PlayListItem
@@ -835,6 +846,14 @@ public class Broadcast {
 
 	public void setAutoStartStopEnabled(boolean autoStartStopEnabled) {
 		this.autoStartStopEnabled = autoStartStopEnabled;
+	}
+
+	public List<EncoderSettings> getEncoderSettings() {
+		return encoderSettings;
+	}
+
+	public void setEncoderSettings(List<EncoderSettings> settings) {
+		encoderSettings = settings;
 	}
 
 }

--- a/src/main/java/io/antmedia/muxer/MuxAdaptor.java
+++ b/src/main/java/io/antmedia/muxer/MuxAdaptor.java
@@ -25,7 +25,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -275,14 +274,17 @@ public class MuxAdaptor implements IRecordingListener, IEndpointStatusListener {
 	//NOSONAR because we need to keep the reference of the field
 	protected AVChannelLayout channelLayout;
 
-	public static MuxAdaptor initializeMuxAdaptor(ClientBroadcastStream clientBroadcastStream, boolean isSource, IScope scope) {
+	public static MuxAdaptor initializeMuxAdaptor(ClientBroadcastStream clientBroadcastStream, List<EncoderSettings> broadcastEncoderSettings, boolean isSource, IScope scope) {
 		MuxAdaptor muxAdaptor = null;
 		ApplicationContext applicationContext = scope.getContext().getApplicationContext();
 		boolean tryEncoderAdaptor = false;
 		if (applicationContext.containsBean(AppSettings.BEAN_NAME)) {
 			AppSettings appSettings = (AppSettings) applicationContext.getBean(AppSettings.BEAN_NAME);
-			List<EncoderSettings> list = appSettings.getEncoderSettings();
-			if ((list != null && !list.isEmpty()) || appSettings.isWebRTCEnabled() || appSettings.isForceDecoding()) {
+			List<EncoderSettings> appEncoderSettings = appSettings.getEncoderSettings();
+
+			if ((broadcastEncoderSettings!= null && !broadcastEncoderSettings.isEmpty()) ||
+					(appEncoderSettings != null && !appEncoderSettings.isEmpty()) ||
+					appSettings.isWebRTCEnabled() || appSettings.isForceDecoding()) {
 				/*
 				 * enable encoder adaptor if webrtc enabled because we're supporting forwarding video to end user
 				 * without transcoding. We need encoder adaptor because we need to transcode audio
@@ -387,7 +389,9 @@ public class MuxAdaptor implements IRecordingListener, IEndpointStatusListener {
 		targetLatency = appSettingsLocal.getTargetLatency();
 
 		previewOverwrite = appSettingsLocal.isPreviewOverwrite();
-		encoderSettingsList = appSettingsLocal.getEncoderSettings();
+
+		encoderSettingsList = (getBroadcast().getEncoderSettings() != null && !getBroadcast().getEncoderSettings().isEmpty()) ? getBroadcast().getEncoderSettings() : appSettingsLocal.getEncoderSettings();
+
 		previewCreatePeriod = appSettingsLocal.getCreatePreviewPeriod();
 		maxAnalyzeDurationMS = appSettingsLocal.getMaxAnalyzeDurationMS();
 		generatePreview = appSettingsLocal.isGeneratePreview();

--- a/src/main/java/io/antmedia/streamsource/StreamFetcher.java
+++ b/src/main/java/io/antmedia/streamsource/StreamFetcher.java
@@ -368,7 +368,7 @@ public class StreamFetcher {
 				}
 
 
-				muxAdaptor = MuxAdaptor.initializeMuxAdaptor(null,true, scope);
+				muxAdaptor = MuxAdaptor.initializeMuxAdaptor(null, broadcast.getEncoderSettings(), true, scope);
 				// if there is only audio, firstKeyFrameReceivedChecked should be true in advance
 				// because there is no video frame
 				muxAdaptor.setFirstKeyFrameReceivedChecked(!videoExist); 

--- a/src/main/java/org/red5/server/stream/ClientBroadcastStream.java
+++ b/src/main/java/org/red5/server/stream/ClientBroadcastStream.java
@@ -24,7 +24,6 @@ import java.lang.management.ManagementFactory;
 import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -88,10 +87,8 @@ import io.antmedia.cluster.IClusterNotifier;
 import io.antmedia.datastore.db.DataStore;
 import io.antmedia.datastore.db.IDataStoreFactory;
 import io.antmedia.datastore.db.types.Broadcast;
-import io.antmedia.datastore.db.types.Endpoint;
 import io.antmedia.muxer.IAntMediaStreamHandler;
 import io.antmedia.muxer.MuxAdaptor;
-import io.antmedia.muxer.RtmpMuxer;
 import io.antmedia.muxer.parser.codec.AACAudio;
 import io.vertx.core.Vertx;
 
@@ -969,7 +966,8 @@ public class ClientBroadcastStream extends AbstractClientStream implements IClie
 			}
 		}
 
-		MuxAdaptor localMuxAdaptor = MuxAdaptor.initializeMuxAdaptor(this, false, conn.getScope());
+
+		MuxAdaptor localMuxAdaptor = MuxAdaptor.initializeMuxAdaptor(this, null, false, conn.getScope());
 
 
 		


### PR DESCRIPTION
This PR allows users to set ABR on broadcast level.
If broadcast level ABR is set app settings ABR is ignored and set ABR for broadcast is used.
To set ABR to a broadcast edit broadcast object:
![image](https://github.com/ant-media/Ant-Media-Server/assets/24750845/771aee95-ce97-4fcc-bcfd-122146b50edb)

https://gitlab.com/Ant-Media/Ant-Media-Enterprise/-/merge_requests/667

https://github.com/ant-media/Ant-Media-Server/issues/6144



