### PR TITLE
allowableValues expects an array to map to enum

### DIFF
--- a/src/main/java/io/antmedia/datastore/db/types/Broadcast.java
+++ b/src/main/java/io/antmedia/datastore/db/types/Broadcast.java
@@ -45,22 +45,22 @@ public class Broadcast {
 	 * "finished", "broadcasting", "created"
 	 */
 
-	@Schema(description = "the status of the stream", allowableValues = "finished,broadcasting,created,preparing,error,failed")
+	@Schema(description = "the status of the stream", allowableValues = {"finished","broadcasting","created","preparing","error","failed"})
 	private String status;
 
-	@Schema(description = "The status of the playlist. It's usable if type is playlist", allowableValues = "finished,broadcasting,created,preparing,error,failed")
+	@Schema(description = "The status of the playlist. It's usable if type is playlist", allowableValues = {"finished","broadcasting","created","preparing","error","failed"})
 	private String playListStatus;
 	
 	/**
 	 * "liveStream", "ipCamera", "streamSource", "VoD"
 	 */
-	@Schema(description = "the type of the stream", allowableValues = "liveStream,ipCamera,streamSource,VoD,playlist")
+	@Schema(description = "the type of the stream", allowableValues = {"liveStream","ipCamera","streamSource","VoD","playlist"})
 	private String type;
 
 	/**
 	 * "WebRTC", "RTMP", "Pull"
 	 */
-	@Schema(description = "The publish type of the stream. It's read-only and its value updated on the server side", allowableValues = "WebRTC,RTMP,Pull")
+	@Schema(description = "The publish type of the stream. It's read-only and its value updated on the server side", allowableValues = {"WebRTC","RTMP","Pull"})
 	private String publishType;
 
 	/**


### PR DESCRIPTION
In swagger.json generation, under 'components.schemas.Broadcasts', a number of enums are defined.
They are defined as having a single value, consisting of a comma separated list of the actual values.
By correctly defining the values as a list of values, this enum export will also result in a list of values.

Currently, when we want to do code generation from this swagger file, we have to actually edit the file received from ant media, making the build process a lot harder than it needs to be.

```json
          "status": {
            "type": "string",
            "description": "the status of the stream",
            "enum": [
              "finished,broadcasting,created,preparing,error,failed"
            ]
          },
          "playListStatus": {
            "type": "string",
            "description": "The status of the playlist. It's usable if type is playlist",
            "enum": [
              "finished,broadcasting,created,preparing,error,failed"
            ]
          },
          "type": {
            "type": "string",
            "description": "the type of the stream",
            "enum": [
              "liveStream,ipCamera,streamSource,VoD,playlist"
            ]
          },
          "publishType": {
            "type": "string",
            "description": "The publish type of the stream. It's read-only and its value updated on the server side",
            "enum": [
              "WebRTC,RTMP,Pull"
            ]
          },
```