### PR TITLE
Fix recording API not returning timestamp and returning 0 instead (#7079).

### DIFF
--- a/src/main/java/io/antmedia/muxer/MuxAdaptor.java
+++ b/src/main/java/io/antmedia/muxer/MuxAdaptor.java
@@ -18,6 +18,9 @@ import static org.bytedeco.ffmpeg.global.avutil.av_malloc;
 import static org.bytedeco.ffmpeg.global.avutil.av_rescale_q;
 
 import java.nio.ByteBuffer;
+import java.time.LocalDateTime;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
@@ -2265,6 +2268,9 @@ public class MuxAdaptor implements IRecordingListener, IEndpointStatusListener {
 		else {
 			logger.error("Unrecognized record type: {}", recordType);
 		}
+
+		LocalDateTime ldt = LocalDateTime.now();
+		muxer.setCurrentVoDTimeStamp(ldt.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
 
 		return muxer;
 	}


### PR DESCRIPTION
Fixes #7079 

## Proposed Changes

  - Recording API gives the created muxer a timestamp of the start of the recording, and also returns it in the API message.