### PR TITLE
Separate env vars in service descriptor for memory, debugging and GC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
-                    <argLine>@{argLine} -Xmx3000M -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -Djava.library.path=${project.basedir}/src/main/server/lib/native-linux-x86_64</argLine>
+                    <argLine>@{argLine} -Xmx3000M -Djava.library.path=${project.basedir}/src/main/server/lib/native-linux-x86_64</argLine>
                 	<skipAfterFailureCount>10</skipAfterFailureCount>
                 </configuration>
             </plugin>

--- a/src/main/server/antmedia.service
+++ b/src/main/server/antmedia.service
@@ -4,10 +4,14 @@ After=syslog.target network.target
 
 [Service]
 Type=simple
-Environment=JVM_MEMORY_OPTIONS=
+Environment=JVM_MEMORY_OPTIONS=-XX:+HeapDumpOnOutOfMemoryError
+# Use JVM_GC_OPTIONS to fine-tune JVM Garbage collection
+Environment=JVM_GC_OPTIONS=-Xlog:gc*,gc+heap=info,safepoint:file=/usr/local/antmedia/log/gc.log:time,uptime,level,tags:filecount=5,filesize=50M
+# Uncomment JVM_DEBUG_OPTIONS to enable JVM remote debugging for Ant Media Server. Change address to *:7777 to listen on all network interfaces.
+# Environment=JVM_DEBUG_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=localhost:7777
 Environment=JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-LimitNOFILE=65536:524288
 Environment=ANTMEDIA_HOME=/usr/local/antmedia
+LimitNOFILE=65536:524288
 WorkingDirectory=/usr/local/antmedia
 RemainAfterExit=no
 Restart=on-failure
@@ -26,7 +30,7 @@ StandardError=append:/usr/local/antmedia/log/antmedia-error.log
 # By default we have disabled jmxremote because it's not secure. If you want to enable it, you can add the following options to the ExecStart line
 # -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=5599 -Dcom.sun.management.jmxremote.local.only=true -Dcom.sun.management.jmxremote.host=127.0.0.1 -Djava.rmi.server.hostname=127.0.0.1 -Djava.rmi.server.useLocalHostname=true -Dcom.sun.management.jmxremote.rmi.port=5599 
 
-ExecStart=/usr/bin/env ${JAVA_HOME}/bin/java -Djava.io.tmpdir=/tmp -XX:ErrorFile=/var/log/antmedia/hs_err_pid%%p.log -Dlogback.ContextSelector=org.red5.logging.LoggingContextSelector -cp ${ANTMEDIA_HOME}/ant-media-server-service.jar:${ANTMEDIA_HOME}/conf -Djava.security.debug=failure -Djava.awt.headless=true -Djava.security.egd=file:/dev/./urandom -Dcatalina.home=${ANTMEDIA_HOME} -Dcatalina.useNaming=true -Dorg.terracotta.quartz.skipUpdateCheck=true -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:ParallelGCThreads=10 -XX:ConcGCThreads=5 -XX:+HeapDumpOnOutOfMemoryError -Djava.library.path=/usr/local/antmedia/lib/native -Xverify:none -XX:+TieredCompilation -XX:+UseBiasedLocking -XX:InitialCodeCacheSize=8m -XX:ReservedCodeCacheSize=32m -Djava.net.preferIPv4Stack=true $JVM_MEMORY_OPTIONS -Djdk.lang.Process.launchMechanism=vfork -Djava.system.class.loader=org.red5.server.classloading.ServerClassLoader -Xshare:off org.red5.server.Bootstrap 9999
+ExecStart=/usr/bin/env ${JAVA_HOME}/bin/java ${JVM_DEBUG_OPTIONS} -Djava.io.tmpdir=/tmp -XX:ErrorFile=/var/log/antmedia/hs_err_pid%%p.log -Dlogback.ContextSelector=org.red5.logging.LoggingContextSelector -cp ${ANTMEDIA_HOME}/ant-media-server-service.jar:${ANTMEDIA_HOME}/conf -Djava.security.debug=failure -Djava.awt.headless=true -Djava.security.egd=file:/dev/./urandom -Dcatalina.home=${ANTMEDIA_HOME} -Dcatalina.useNaming=true -Dorg.terracotta.quartz.skipUpdateCheck=true ${JVM_GC_OPTS}  -Djava.library.path=/usr/local/antmedia/lib/native -Xverify:none -XX:+TieredCompilation -XX:+UseBiasedLocking -XX:InitialCodeCacheSize=8m -XX:ReservedCodeCacheSize=32m -Djava.net.preferIPv4Stack=true $JVM_MEMORY_OPTIONS -Djdk.lang.Process.launchMechanism=vfork -Djava.system.class.loader=org.red5.server.classloading.ServerClassLoader -Xshare:off org.red5.server.Bootstrap 9999
 
 [Install]
 WantedBy=multi-user.target

--- a/src/main/server/start.sh
+++ b/src/main/server/start.sh
@@ -216,7 +216,7 @@ echo "Running on " $OS
 # JAVA options
 # You can set JVM additional options here if you want
 if [ -z "$JVM_OPTS" ]; then
-    JVM_OPTS="$JVM_MEMORY_OPTIONS -Djava.io.tmpdir=/tmp -XX:ErrorFile=/var/log/antmedia/hs_err_${TIMESTAMP}.log -Djava.awt.headless=true -Xverify:none -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:+UseBiasedLocking -XX:InitialCodeCacheSize=8m -XX:ReservedCodeCacheSize=32m -Dorg.terracotta.quartz.skipUpdateCheck=true -XX:MaxMetaspaceSize=128m  -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:ParallelGCThreads=10 -XX:ConcGCThreads=5 -Djava.system.class.loader=org.red5.server.classloading.ServerClassLoader -Xshare:off "
+    JVM_OPTS="$JVM_MEMORY_OPTIONS -Djava.io.tmpdir=/tmp -XX:ErrorFile=/var/log/antmedia/hs_err_${TIMESTAMP}.log -Djava.awt.headless=true -Xverify:none -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:+UseBiasedLocking -XX:InitialCodeCacheSize=8m -XX:ReservedCodeCacheSize=32m -Dorg.terracotta.quartz.skipUpdateCheck=true -XX:MaxMetaspaceSize=128m -Djava.system.class.loader=org.red5.server.classloading.ServerClassLoader -Xshare:off "
 fi
 # Set up security options
 SECURITY_OPTS="-Djava.security.debug=failure -Djava.security.egd=file:/dev/./urandom"


### PR DESCRIPTION
This change in the service descriptor makes dev life easier by enabling easier JVM debugging
The unnecessary explicit G1GC usage declaration is removed, it had inconsistent target pause time, the default is 200ms without tuning. The thread counts were most likely restricting performance, it is best leaving it up to the JVM and only tune it if the processor details are known in the environment.