### PR TITLE
Fix buffered packet removal order

### DIFF
--- a/src/main/java/io/antmedia/streamsource/StreamFetcher.java
+++ b/src/main/java/io/antmedia/streamsource/StreamFetcher.java
@@ -959,9 +959,11 @@ public class StreamFetcher {
 								if (pktTimeDifferenceMs < passedTime)
 								{
 
-									writePacket(inputFormatContext.streams(tempPacket.stream_index()), tempPacket);
-									bufferQueue.remove(tempPacket); //remove the packet from the queue
-									unReferencePacket(tempPacket);
+									tempPacket = bufferQueue.pollFirst();
+									if (tempPacket != null) {
+										writePacket(inputFormatContext.streams(tempPacket.stream_index()), tempPacket);
+										unReferencePacket(tempPacket);
+									}
 								}
 								else {
 									//break the loop and don't block the thread because it's not correct time to send the packet

--- a/src/main/java/io/antmedia/streamsource/StreamFetcher.java
+++ b/src/main/java/io/antmedia/streamsource/StreamFetcher.java
@@ -958,12 +958,7 @@ public class StreamFetcher {
 
 								if (pktTimeDifferenceMs < passedTime)
 								{
-
-									tempPacket = bufferQueue.pollFirst();
-									if (tempPacket != null) {
-										writePacket(inputFormatContext.streams(tempPacket.stream_index()), tempPacket);
-										unReferencePacket(tempPacket);
-									}
+									writeFirstBufferedPacket();
 								}
 								else {
 									//break the loop and don't block the thread because it's not correct time to send the packet
@@ -989,6 +984,14 @@ public class StreamFetcher {
 					}
 				}
 
+			}
+		}
+
+		private void writeFirstBufferedPacket() {
+			AVPacket packet = bufferQueue.pollFirst();
+			if (packet != null) {
+				writePacket(inputFormatContext.streams(packet.stream_index()), packet);
+				unReferencePacket(packet);
 			}
 		}
 


### PR DESCRIPTION
## What changed

- Remove the first buffered packet from `bufferQueue` before writing it.
- Use `pollFirst()` so removal and retrieval happen as one queue operation.
- Guard against a null result before writing and unreferencing the packet.

## Why

`bufferQueue` is a `ConcurrentSkipListSet` ordered by packet DTS. The previous code called `writePacket()` before removing the packet, but `writePacket()` mutates its DTS and PTS. Mutating the ordering key while the packet was still in the set could make `remove()` fail.

The stale packet was then unreferenced while remaining in the queue and processed repeatedly with `AV_NOPTS_VALUE`. This produced millions of repeated DTS messages, blocked stream cleanup, left the temporary MP4 file visible to the test, and generated a 1.6 GiB JUnit report that the report publisher could not parse as a Node.js string.

## Impact

Buffered packets are now removed before their timestamps are changed, preventing stale packets from becoming stuck in the queue and allowing stream finalization to complete normally.

## Validation

- `mvn -q -Dtest=io.antmedia.test.StreamFetcherUnitTest#testStreamFetcherBuffer test`
- `git diff --check`
- The focused test passed and produced an approximately 100 KiB JUnit XML report with no repeated `AV_NOPTS_VALUE` DTS messages.
