### PR TITLE
Add CI experiment for SRT artifact comparison

### DIFF
--- a/.github/scripts/compare-srt-artifacts.sh
+++ b/.github/scripts/compare-srt-artifacts.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly SRT_VERSION="1.5.3-1.5.11"
+readonly CI_REPOSITORY="${HOME}/.m2/repository"
+readonly GITHUB_REPOSITORY="/tmp/srt-github-repository"
+readonly REPORT_DIRECTORY="/tmp/srt-artifact-comparison"
+readonly EXPERIMENT_POM="${REPORT_DIRECTORY}/pom.xml"
+
+readonly -a ARTIFACTS=(
+  "org/bytedeco/srt/${SRT_VERSION}/srt-${SRT_VERSION}.jar"
+  "org/bytedeco/srt/${SRT_VERSION}/srt-${SRT_VERSION}.pom"
+  "org/bytedeco/srt/${SRT_VERSION}/srt-${SRT_VERSION}-linux-arm64.jar"
+  "org/bytedeco/srt/${SRT_VERSION}/srt-${SRT_VERSION}-linux-x86_64.jar"
+  "org/bytedeco/srt-platform/${SRT_VERSION}/srt-platform-${SRT_VERSION}.jar"
+  "org/bytedeco/srt-platform/${SRT_VERSION}/srt-platform-${SRT_VERSION}.pom"
+)
+
+mkdir -p "${REPORT_DIRECTORY}"
+
+for artifact in "${ARTIFACTS[@]}"; do
+  if [[ ! -f "${CI_REPOSITORY}/${artifact}" ]]; then
+    echo "Missing CI-cached artifact: ${artifact}" | tee -a "${REPORT_DIRECTORY}/missing-ci-artifacts.txt"
+  fi
+done
+
+if [[ -f "${REPORT_DIRECTORY}/missing-ci-artifacts.txt" ]]; then
+  echo "The restored CI Maven cache does not contain the complete SRT artifact set." >&2
+  exit 1
+fi
+
+cat > "${EXPERIMENT_POM}" <<'EOF'
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.antmedia.experiment</groupId>
+  <artifactId>srt-artifact-comparison</artifactId>
+  <version>1</version>
+  <repositories>
+    <repository>
+      <id>github</id>
+      <url>https://maven.pkg.github.com/ant-media/javacpp-presets</url>
+    </repository>
+  </repositories>
+  <dependencies>
+    <dependency>
+      <groupId>org.bytedeco</groupId>
+      <artifactId>srt-platform</artifactId>
+      <version>1.5.3-1.5.11</version>
+    </dependency>
+  </dependencies>
+</project>
+EOF
+
+mvn --batch-mode \
+  --settings mvn-settings.xml \
+  --file "${EXPERIMENT_POM}" \
+  -Dmaven.repo.local="${GITHUB_REPOSITORY}" \
+  dependency:go-offline
+
+comparison_failed=0
+: > "${REPORT_DIRECTORY}/ci-sha256.txt"
+: > "${REPORT_DIRECTORY}/github-sha256.txt"
+: > "${REPORT_DIRECTORY}/comparison.txt"
+
+for artifact in "${ARTIFACTS[@]}"; do
+  ci_file="${CI_REPOSITORY}/${artifact}"
+  github_file="${GITHUB_REPOSITORY}/${artifact}"
+
+  if [[ ! -f "${github_file}" ]]; then
+    echo "MISSING_FROM_GITHUB ${artifact}" | tee -a "${REPORT_DIRECTORY}/comparison.txt"
+    comparison_failed=1
+    continue
+  fi
+
+  sha256sum "${ci_file}" | sed "s#${CI_REPOSITORY}/##" >> "${REPORT_DIRECTORY}/ci-sha256.txt"
+  sha256sum "${github_file}" | sed "s#${GITHUB_REPOSITORY}/##" >> "${REPORT_DIRECTORY}/github-sha256.txt"
+
+  if cmp --silent "${ci_file}" "${github_file}"; then
+    echo "IDENTICAL ${artifact}" | tee -a "${REPORT_DIRECTORY}/comparison.txt"
+  else
+    echo "DIFFERENT ${artifact}" | tee -a "${REPORT_DIRECTORY}/comparison.txt"
+    comparison_failed=1
+  fi
+done
+
+exit "${comparison_failed}"

--- a/.github/scripts/compare-srt-artifacts.sh
+++ b/.github/scripts/compare-srt-artifacts.sh
@@ -25,11 +25,6 @@ for artifact in "${ARTIFACTS[@]}"; do
   fi
 done
 
-if [[ -f "${REPORT_DIRECTORY}/missing-ci-artifacts.txt" ]]; then
-  echo "The restored CI Maven cache does not contain the complete SRT artifact set." >&2
-  exit 1
-fi
-
 cat > "${EXPERIMENT_POM}" <<'EOF'
 <project xmlns="http://maven.apache.org/POM/4.0.0">
   <modelVersion>4.0.0</modelVersion>
@@ -66,6 +61,12 @@ comparison_failed=0
 for artifact in "${ARTIFACTS[@]}"; do
   ci_file="${CI_REPOSITORY}/${artifact}"
   github_file="${GITHUB_REPOSITORY}/${artifact}"
+
+  if [[ ! -f "${ci_file}" ]]; then
+    echo "MISSING_FROM_CI_CACHE ${artifact}" | tee -a "${REPORT_DIRECTORY}/comparison.txt"
+    comparison_failed=1
+    continue
+  fi
 
   if [[ ! -f "${github_file}" ]]; then
     echo "MISSING_FROM_GITHUB ${artifact}" | tee -a "${REPORT_DIRECTORY}/comparison.txt"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,34 @@ env:
   RUNNER: ubuntu-22.04      
       
 jobs:  
+  compare-srt-artifacts:
+    name: Compare cached and GitHub SRT artifacts
+    runs-on: ubuntu-22.04
+    env:
+      GITHUB_MAVEN_REPO_USER: ${{ secrets.GITHUB_MAVEN_REPO_USER }}
+      GITHUB_MAVEN_REPO_PASSWORD: ${{ secrets.GITHUB_MAVEN_REPO_PASSWORD }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17 and restore the CI Maven cache
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: Compare SRT artifacts byte-for-byte
+        run: .github/scripts/compare-srt-artifacts.sh
+
+      - name: Upload SRT comparison report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: srt-artifact-comparison
+          path: /tmp/srt-artifact-comparison/
+          if-no-files-found: warn
+
   run-unit-tests:
     name: Run unit tests
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: read
   checks: write
+  packages: read
   
       
 env:
@@ -24,8 +25,8 @@ jobs:
     name: Compare cached and GitHub SRT artifacts
     runs-on: ubuntu-22.04
     env:
-      GITHUB_MAVEN_REPO_USER: ${{ secrets.GITHUB_MAVEN_REPO_USER }}
-      GITHUB_MAVEN_REPO_PASSWORD: ${{ secrets.GITHUB_MAVEN_REPO_PASSWORD }}
+      GITHUB_MAVEN_REPO_USER: ${{ github.actor }}
+      GITHUB_MAVEN_REPO_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## What changed

Adds a temporary GitHub Actions job that compares the SRT Maven artifacts restored from the CI Maven cache with a fresh resolution from the private `ant-media/javacpp-presets` GitHub Packages repository.

The experiment:

- snapshots the CI baseline before running any project build
- resolves `org.bytedeco:srt-platform:1.5.3-1.5.11` and its transitive artifacts into an isolated Maven repository
- compares the main SRT JAR, Linux classifiers, platform JAR, and both POMs with `cmp`
- records SHA-256 manifests for both sources
- uploads the comparison report even when the check fails
- fails if the CI cache lacks a complete baseline, a GitHub artifact is missing, or any artifact differs byte-for-byte

## Why

Issue #7948 proposes replacing manually seeded SRT dependencies with artifacts from GitHub Packages. This diagnostic verifies that the proposed package files are byte-for-byte identical to the copies currently used by CI before removing the workaround.

Closes no issue; this PR is an experiment for #7948 and is intended to be removed or superseded after the result is captured.

## Validation

- `bash -n .github/scripts/compare-srt-artifacts.sh`
- `git diff --check`
- Confirmed the expected six SRT JAR/POM files exist in the local Maven baseline

The definitive validation is the new **Compare cached and GitHub SRT artifacts** CI job.
