### PR TITLE
Fix CommonRestService dependency injection

### DIFF
--- a/src/main/java/io/antmedia/cluster/IClusterNotifier.java
+++ b/src/main/java/io/antmedia/cluster/IClusterNotifier.java
@@ -6,14 +6,14 @@ import io.antmedia.IDeleteAppListener;
 
 public interface IClusterNotifier {
 	
-	public static final String BEAN_NAME = "tomcat.cluster";
+	String BEAN_NAME = "tomcat.cluster";
 	
-	public IClusterStore getClusterStore();
+	IClusterStore getClusterStore();
 	
-	public void registerSettingUpdateListener(String appName, IAppSettingsUpdateListener listener);
+	void registerSettingUpdateListener(String appName, IAppSettingsUpdateListener listener);
 	
-	public void registerCreateAppListener(ICreateAppListener createApplistener);
+	void registerCreateAppListener(ICreateAppListener createApplistener);
 	
-	public void registerDeleteAppListener(IDeleteAppListener deleteApplistener);
+	void registerDeleteAppListener(IDeleteAppListener deleteApplistener);
 
 }

--- a/src/main/java/io/antmedia/console/rest/CommonRestService.java
+++ b/src/main/java/io/antmedia/console/rest/CommonRestService.java
@@ -38,6 +38,8 @@ import org.red5.server.Launcher;
 import org.red5.server.api.scope.IScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
@@ -45,6 +47,7 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.common.annotations.VisibleForTesting;
 
 import ch.qos.logback.classic.Level;
 import io.antmedia.AntMediaApplicationAdapter;
@@ -136,8 +139,6 @@ public class CommonRestService {
 
 	private static final String LICENSE_STATUS = "license";
 
-	protected ApplicationContext applicationContext;
-
 	@Context
 	private ServletContext servletContext;
 
@@ -147,9 +148,11 @@ public class CommonRestService {
 	private ConsoleDataStoreFactory dataStoreFactory;
 	private ServerSettings serverSettings;
 
-	private ILicenceService licenceService;
+	private Optional<ILicenceService> licenceService = Optional.empty();
 
 	private IStatsCollector statsCollector;
+
+	private AdminApplication application;
 
 	private static final int BLOCKED_LOGIN_TIMEOUT_SECS = 300 ; // in seconds
 
@@ -1152,15 +1155,13 @@ public class CommonRestService {
 	}
 
 
-	public IStatsCollector getStatsCollector () {
-		if(statsCollector == null) 
-		{
-			WebApplicationContext ctxt =getContext();
-			if (ctxt != null) {
-				statsCollector = (IStatsCollector)ctxt.getBean(IStatsCollector.BEAN_NAME);
-			}
-		}
+	public IStatsCollector getStatsCollector() {
 		return statsCollector;
+	}
+
+	@Autowired
+	public void setStatsCollector(IStatsCollector statsCollector) {
+		this.statsCollector = Objects.requireNonNull(statsCollector, "Stats collector is not initialized");
 	}
 
 	public ServerSettings getServerSettings() 
@@ -1170,16 +1171,18 @@ public class CommonRestService {
 
 	public Licence getLicenceStatus(@QueryParam("key") String key) 
 	{
-		if(key == null) {
+		ILicenceService service = getLicenceServiceInstance();
+		if(key == null || service == null) {
 			return null;
 		}
-		return getLicenceServiceInstance().checkLicence(key);
+		return service.checkLicence(key);
 	}
 
 
 	public Licence getLicenceStatus() 
 	{
-		return getLicenceServiceInstance().getLastLicenseStatus();
+		ILicenceService service = getLicenceServiceInstance();
+		return service != null ? service.getLastLicenseStatus() : null;
 	}
 
 	/**
@@ -1199,14 +1202,12 @@ public class CommonRestService {
 		return new Result(false, "No application adaptor with this name " + appname);
 	}
 
+	@VisibleForTesting
 	public void setDataStore(AbstractConsoleDataStore dataStore) {
 		this.dataStore = dataStore;
 	}
 
 	public AbstractConsoleDataStore getDataStore() {
-		if (dataStore == null) {
-			dataStore = getDataStoreFactory().getDataStore();
-		}
 		return dataStore;
 	}
 
@@ -1215,52 +1216,43 @@ public class CommonRestService {
 	}
 
 	public ServerSettings getServerSettingsInternal() {
-
-		if(serverSettings == null) 
-		{
-			WebApplicationContext ctxt = getContext();
-			if (ctxt != null) {
-				serverSettings = (ServerSettings)ctxt.getBean(ServerSettings.BEAN_NAME);
-			}
-		}
 		return serverSettings;
+	}
+
+	@Autowired
+	public void setServerSettings(ServerSettings serverSettings) {
+		this.serverSettings = Objects.requireNonNull(serverSettings, "Server settings are not initialized");
 	}
 
 
 
-	public ILicenceService getLicenceServiceInstance () {
-		if(licenceService == null) {
+	public ILicenceService getLicenceServiceInstance() {
+		return licenceService.orElse(null);
+	}
 
-			WebApplicationContext ctxt = getContext();
-			if (ctxt != null) {
-				licenceService = (ILicenceService)ctxt.getBean(ILicenceService.BEAN_NAME);
-			}
-		}
-		return licenceService;
+	@Autowired
+	public void setLicenceService(Optional<ILicenceService> licenceService) {
+		this.licenceService = Objects.requireNonNull(licenceService);
 	}
 
 
 	public AdminApplication getApplication() {
-		WebApplicationContext ctxt = getContext();
-		if (ctxt != null) {
-			return (AdminApplication)ctxt.getBean("web.handler");
-		}
-		return null;
+		return application;
+	}
+
+	@Autowired
+	public void setApplication(@Qualifier("web.handler") AdminApplication application) {
+		this.application = Objects.requireNonNull(application, "Admin application is not initialized");
 	}
 
 	public ConsoleDataStoreFactory getDataStoreFactory() {
-		if(dataStoreFactory == null)
-		{
-			WebApplicationContext ctxt = getContext();
-			if (ctxt != null) {
-				dataStoreFactory = (ConsoleDataStoreFactory) ctxt.getBean("dataStoreFactory");
-			}
-		}
 		return dataStoreFactory;
 	}
 
+	@Autowired
 	public void setDataStoreFactory(ConsoleDataStoreFactory dataStoreFactory) {
-		this.dataStoreFactory = dataStoreFactory;
+		this.dataStoreFactory = Objects.requireNonNull(dataStoreFactory, "Console data store factory is not initialized");
+		this.dataStore = Objects.requireNonNull(dataStoreFactory.getDataStore(), "Console data store is not initialized");
 	}
 
 

--- a/src/main/java/io/antmedia/console/rest/CommonRestService.java
+++ b/src/main/java/io/antmedia/console/rest/CommonRestService.java
@@ -42,6 +42,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 
 import com.google.gson.Gson;
@@ -72,6 +73,7 @@ import io.antmedia.security.SslConfigurator;
 import io.antmedia.settings.ServerSettings;
 import io.antmedia.statistic.IStatsCollector;
 import io.antmedia.statistic.StatsCollector;
+import jakarta.annotation.PostConstruct;
 import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
@@ -170,6 +172,13 @@ public class CommonRestService {
 
 	public int getAllowedLoginAttempts() {
 		return ALLOWED_LOGIN_ATTEMPTS;
+	}
+
+	@PostConstruct
+	public void initializeSpringDependencies() {
+		if (dataStoreFactory == null && servletContext != null) {
+			SpringBeanAutowiringSupport.processInjectionBasedOnServletContext(this, servletContext);
+		}
 	}
 
 

--- a/src/main/java/io/antmedia/console/rest/CommonRestService.java
+++ b/src/main/java/io/antmedia/console/rest/CommonRestService.java
@@ -733,18 +733,18 @@ public class CommonRestService {
 
 	public String getSystemResourcesInfo() {
 
-		AdminApplication application = getApplication();
-		IScope rootScope = application.getRootScope();
+		AdminApplication app = getApplication();
+		IScope rootScope = app.getRootScope();
 
 		//add live stream size
 		int totalLiveStreams = 0;
 		Queue<IScope> scopes = new LinkedList<>();
-		List<String> appNames = application.getApplications();
+		List<String> appNames = app.getApplications();
 		for (String name : appNames) 
 		{
 			IScope scope = rootScope.getScope(name);
 			scopes.add(scope);
-			totalLiveStreams += application.getAppLiveStreamCount(scope);
+			totalLiveStreams += app.getAppLiveStreamCount(scope);
 		}
 
 		JsonObject jsonObject = StatsCollector.getSystemResourcesInfo(scopes);
@@ -868,10 +868,10 @@ public class CommonRestService {
 	public AntMediaApplicationAdapter getAppAdaptor(String appName) {
 
 		AntMediaApplicationAdapter appAdaptor = null;
-		AdminApplication application = getApplication();
-		if (application != null) 
+		AdminApplication app = getApplication();
+		if (app != null)
 		{
-			ApplicationContext context = application.getApplicationContext(appName);
+			ApplicationContext context = app.getApplicationContext(appName);
 			if (context != null) 
 			{
 				appAdaptor = (AntMediaApplicationAdapter) context.getBean(AntMediaApplicationAdapter.BEAN_NAME);

--- a/src/test/java/io/antmedia/console/rest/CommonRestServiceTest.java
+++ b/src/test/java/io/antmedia/console/rest/CommonRestServiceTest.java
@@ -1,6 +1,7 @@
 package io.antmedia.console.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -20,6 +21,24 @@ import io.antmedia.test.UnitTestBase;
 
 @Tag("fast")
 class CommonRestServiceTest extends UnitTestBase<CommonRestService> {
+
+	@Test
+	void shouldSkipSpringInjectionWhenDependenciesAreAlreadyInjected() {
+		AbstractConsoleDataStore dataStore = mock(AbstractConsoleDataStore.class);
+		ConsoleDataStoreFactory dataStoreFactory = mock(ConsoleDataStoreFactory.class);
+		when(dataStoreFactory.getDataStore()).thenReturn(dataStore);
+		classUnderTest = new CommonRestService();
+		classUnderTest.setDataStoreFactory(dataStoreFactory);
+
+		assertThatCode(classUnderTest::initializeSpringDependencies).doesNotThrowAnyException();
+	}
+
+	@Test
+	void shouldSkipSpringInjectionWithoutServletContext() {
+		classUnderTest = new CommonRestService();
+
+		assertThatCode(classUnderTest::initializeSpringDependencies).doesNotThrowAnyException();
+	}
 
 	@Test
 	void shouldInjectSpringDependenciesIntoJerseyManagedInstance() {

--- a/src/test/java/io/antmedia/console/rest/CommonRestServiceTest.java
+++ b/src/test/java/io/antmedia/console/rest/CommonRestServiceTest.java
@@ -3,10 +3,17 @@ package io.antmedia.console.rest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.red5.server.api.scope.IScope;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.WebApplicationContext;
@@ -17,10 +24,41 @@ import io.antmedia.console.datastore.AbstractConsoleDataStore;
 import io.antmedia.console.datastore.ConsoleDataStoreFactory;
 import io.antmedia.settings.ServerSettings;
 import io.antmedia.statistic.IStatsCollector;
+import io.antmedia.statistic.StatsCollector;
 import io.antmedia.test.UnitTestBase;
 
 @Tag("fast")
 class CommonRestServiceTest extends UnitTestBase<CommonRestService> {
+
+	@Test
+	void shouldReturnNullAppAdaptorWithoutApplication() {
+		classUnderTest = new CommonRestService();
+
+		assertThat(classUnderTest.getAppAdaptor("app")).isNull();
+	}
+
+	@Test
+	void shouldIncludeApplicationLiveStreamCountInSystemResources() {
+		AdminApplication application = mock(AdminApplication.class);
+		IScope rootScope = mock(IScope.class);
+		IScope appScope = mock(IScope.class);
+		when(application.getRootScope()).thenReturn(rootScope);
+		when(application.getApplications()).thenReturn(List.of("app"));
+		when(rootScope.getScope("app")).thenReturn(appScope);
+		when(application.getAppLiveStreamCount(appScope)).thenReturn(3);
+
+		classUnderTest = new CommonRestService();
+		classUnderTest.setApplication(application);
+
+		try (MockedStatic<StatsCollector> statsCollector = mockStatic(StatsCollector.class)) {
+			statsCollector.when(() -> StatsCollector.getSystemResourcesInfo(org.mockito.ArgumentMatchers.any()))
+					.thenReturn(new JsonObject());
+
+			JsonObject result = JsonParser.parseString(classUnderTest.getSystemResourcesInfo()).getAsJsonObject();
+
+			assertThat(result.get(StatsCollector.TOTAL_LIVE_STREAMS).getAsInt()).isEqualTo(3);
+		}
+	}
 
 	@Test
 	void shouldSkipSpringInjectionWhenDependenciesAreAlreadyInjected() {

--- a/src/test/java/io/antmedia/console/rest/CommonRestServiceTest.java
+++ b/src/test/java/io/antmedia/console/rest/CommonRestServiceTest.java
@@ -1,0 +1,57 @@
+package io.antmedia.console.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.StaticWebApplicationContext;
+
+import io.antmedia.console.AdminApplication;
+import io.antmedia.console.datastore.AbstractConsoleDataStore;
+import io.antmedia.console.datastore.ConsoleDataStoreFactory;
+import io.antmedia.settings.ServerSettings;
+import io.antmedia.statistic.IStatsCollector;
+import io.antmedia.test.UnitTestBase;
+
+@Tag("fast")
+class CommonRestServiceTest extends UnitTestBase<CommonRestService> {
+
+	@Test
+	void shouldInjectSpringDependenciesIntoJerseyManagedInstance() {
+		MockServletContext servletContext = new MockServletContext();
+		StaticWebApplicationContext springContext = new StaticWebApplicationContext();
+		springContext.setServletContext(servletContext);
+
+		AbstractConsoleDataStore dataStore = mock(AbstractConsoleDataStore.class);
+		ConsoleDataStoreFactory dataStoreFactory = mock(ConsoleDataStoreFactory.class);
+		when(dataStoreFactory.getDataStore()).thenReturn(dataStore);
+		ServerSettings serverSettings = mock(ServerSettings.class);
+		IStatsCollector statsCollector = mock(IStatsCollector.class);
+		AdminApplication application = mock(AdminApplication.class);
+
+		springContext.getBeanFactory().registerSingleton("dataStoreFactory", dataStoreFactory);
+		springContext.getBeanFactory().registerSingleton(ServerSettings.BEAN_NAME, serverSettings);
+		springContext.getBeanFactory().registerSingleton(IStatsCollector.BEAN_NAME, statsCollector);
+		springContext.getBeanFactory().registerSingleton("web.handler", application);
+		springContext.refresh();
+		servletContext.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, springContext);
+
+		classUnderTest = new CommonRestService();
+		ReflectionTestUtils.setField(classUnderTest, "servletContext", servletContext);
+		classUnderTest.initializeSpringDependencies();
+
+		assertThat(classUnderTest.getDataStoreFactory()).isSameAs(dataStoreFactory);
+		assertThat(classUnderTest.getDataStore()).isSameAs(dataStore);
+		assertThat(classUnderTest.getServerSettings()).isSameAs(serverSettings);
+		assertThat(classUnderTest.getStatsCollector()).isSameAs(statsCollector);
+		assertThat(classUnderTest.getApplication()).isSameAs(application);
+		assertThat(classUnderTest.getLicenceServiceInstance()).isNull();
+
+		springContext.close();
+	}
+}

--- a/src/test/java/io/antmedia/test/console/ConsoleRestV2UnitTest.java
+++ b/src/test/java/io/antmedia/test/console/ConsoleRestV2UnitTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import com.google.gson.JsonObject;
@@ -301,76 +302,56 @@ public class ConsoleRestV2UnitTest {
 
 	@Test
 	public void testGetStatsCollector() {
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
-		Mockito.doReturn(null).when(restServiceSpy).getContext();
+		IStatsCollector statsCollector = Mockito.mock(IStatsCollector.class);
 
-		assertNull(restServiceSpy.getStatsCollector());
-		WebApplicationContext context = Mockito.mock(WebApplicationContext.class);
-		Mockito.doReturn(context).when(restServiceSpy).getContext();
-		Mockito.when(context.getBean(Mockito.anyString())).thenReturn(Mockito.mock(IStatsCollector.class));
+		restService.setStatsCollector(statsCollector);
 
-		assertNotNull(restServiceSpy.getStatsCollector());
-		assertNotNull(restServiceSpy.getStatsCollector());
+		assertEquals(statsCollector, restService.getStatsCollector());
 
 	}
 
 	@Test
 	public void testGetServerSettingsInternal() {
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
-		Mockito.doReturn(null).when(restServiceSpy).getContext();
+		ServerSettings serverSettings = Mockito.mock(ServerSettings.class);
 
-		assertNull(restServiceSpy.getServerSettingsInternal());
-		WebApplicationContext context = Mockito.mock(WebApplicationContext.class);
-		Mockito.doReturn(context).when(restServiceSpy).getContext();
-		Mockito.when(context.getBean(Mockito.anyString())).thenReturn(Mockito.mock(ServerSettings.class));
+		restService.setServerSettings(serverSettings);
 
-		assertNotNull(restServiceSpy.getServerSettingsInternal());
-		assertNotNull(restServiceSpy.getServerSettingsInternal());
+		assertEquals(serverSettings, restService.getServerSettingsInternal());
+		assertEquals(serverSettings, restService.getServerSettings());
 
 	}
 
 	@Test
 	public void testGetLicenseService() {
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
-		Mockito.doReturn(null).when(restServiceSpy).getContext();
+		ILicenceService licenceService = Mockito.mock(ILicenceService.class);
+		assertNull(restService.getLicenceStatus());
+		assertNull(restService.getLicenceStatus("licence-key"));
 
-		assertNull(restServiceSpy.getLicenceServiceInstance());
-		WebApplicationContext context = Mockito.mock(WebApplicationContext.class);
-		Mockito.doReturn(context).when(restServiceSpy).getContext();
-		Mockito.when(context.getBean(Mockito.anyString())).thenReturn(Mockito.mock(ILicenceService.class));
+		restService.setLicenceService(Optional.of(licenceService));
 
-		assertNotNull(restServiceSpy.getLicenceServiceInstance());
-		assertNotNull(restServiceSpy.getLicenceServiceInstance());
+		assertEquals(licenceService, restService.getLicenceServiceInstance());
 
 	}
 
 	@Test
 	public void testGetApplication() {
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
-		Mockito.doReturn(null).when(restServiceSpy).getContext();
+		AdminApplication application = Mockito.mock(AdminApplication.class);
 
-		assertNull(restServiceSpy.getApplication());
-		WebApplicationContext context = Mockito.mock(WebApplicationContext.class);
-		Mockito.doReturn(context).when(restServiceSpy).getContext();
-		Mockito.when(context.getBean(Mockito.anyString())).thenReturn(Mockito.mock(AdminApplication.class));
+		restService.setApplication(application);
 
-		assertNotNull(restServiceSpy.getApplication());
-		assertNotNull(restServiceSpy.getApplication());
+		assertEquals(application, restService.getApplication());
 
 	}
 
 	@Test
 	public void testDataStoreFactory() {
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
-		Mockito.doReturn(null).when(restServiceSpy).getContext();
+		ConsoleDataStoreFactory dataStoreFactory = Mockito.mock(ConsoleDataStoreFactory.class);
+		Mockito.when(dataStoreFactory.getDataStore()).thenReturn(dbStore);
 
-		assertNull(restServiceSpy.getDataStoreFactory());
-		WebApplicationContext context = Mockito.mock(WebApplicationContext.class);
-		Mockito.doReturn(context).when(restServiceSpy).getContext();
-		Mockito.when(context.getBean(Mockito.anyString())).thenReturn(Mockito.mock(ConsoleDataStoreFactory.class));
+		restService.setDataStoreFactory(dataStoreFactory);
 
-		assertNotNull(restServiceSpy.getDataStoreFactory());
-		assertNotNull(restServiceSpy.getDataStoreFactory());
+		assertEquals(dataStoreFactory, restService.getDataStoreFactory());
+		assertEquals(dbStore, restService.getDataStore());
 
 	}
 

--- a/src/test/java/io/antmedia/test/console/ConsoleRestV2UnitTest.java
+++ b/src/test/java/io/antmedia/test/console/ConsoleRestV2UnitTest.java
@@ -34,7 +34,6 @@ import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.red5.server.api.scope.IScope;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.context.WebApplicationContext;
@@ -60,6 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.times;
 
 
@@ -77,16 +77,18 @@ public class ConsoleRestV2UnitTest {
 
 	@Rule
 	public TestRule watcher = new TestWatcher() {
+		@Override
 		protected void starting(Description description) {
 			System.out.println("Starting test: " + description.getMethodName());
 		}
-
+		@Override
 		protected void failed(Throwable e, Description description) {
 			System.out.println("Failed test: " + description.getMethodName());
-		};
+		}
+		@Override
 		protected void finished(Description description) {
 			System.out.println("Finishing test: " + description.getMethodName());
-		};
+		}
 	};
 	
 	@BeforeEach
@@ -107,7 +109,6 @@ public class ConsoleRestV2UnitTest {
 
 	@AfterEach
 	void after() {
-		// dbStore.clear();
 		dbStore.close();
 		vertx.close();
 
@@ -125,12 +126,11 @@ public class ConsoleRestV2UnitTest {
 		String password = "password";
 		String userName = "username" + (int) (Math.random() * 1000000000);
 		User user = new User(userName, password, UserType.ADMIN, "all", null);
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
-		Mockito.doReturn(new ServerSettings()).when(restServiceSpy).getServerSettings();
+		RestServiceV2 restServiceSpy = spy(restService);
+		doReturn(new ServerSettings()).when(restServiceSpy).getServerSettings();
 
 		Result result = restServiceSpy.addUser(user);
 
-		// System.out.println("error id: " + result.errorId);
 		assertTrue(result.isSuccess());
 		assertEquals(1, restServiceSpy.getUserList().size());
 
@@ -152,13 +152,12 @@ public class ConsoleRestV2UnitTest {
 		String password = "password";
 		String userName = "username" + (int) (Math.random() * 1000000000);
 		User user = new User(userName, password, UserType.ADMIN, "system", new HashMap<String, String>());
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
-		Mockito.doReturn(new ServerSettings()).when(restServiceSpy).getServerSettings();
+		RestServiceV2 restServiceSpy = spy(restService);
+		doReturn(new ServerSettings()).when(restServiceSpy).getServerSettings();
 
 		
 		Result result = restServiceSpy.addUser(user);
 
-		// System.out.println("error id: " + result.errorId);
 		assertTrue(result.isSuccess());
 
 		String userName2 = "username" + (int) (Math.random() * 1000000000);
@@ -207,6 +206,7 @@ public class ConsoleRestV2UnitTest {
 		err = false;
 		for (int i = 0; i < 10; i++) {
 			thread = new Thread() {
+				@Override
 				public void run() {
 
 					for (int i = 0; i < 20; i++) {
@@ -215,26 +215,21 @@ public class ConsoleRestV2UnitTest {
 						} catch (Exception e) {
 							e.printStackTrace();
 							System.err.println("error--------");
-							// fail(e.getMessage());
 							err = true;
 						} catch (AssertionError error) {
 							error.printStackTrace();
 							System.err.println("assertion error: " + error);
-							// fail(error.getMessage());
 							err = true;
 
 						}
 					}
 
-				};
+				}
 			};
 			thread.start();
 		}
 
 		try {
-			/*
-			 * while (thread.isAlive()) { Thread.sleep(1000); }
-			 */
 			thread.join();
 			assertFalse(err);
 		} catch (InterruptedException e) {
@@ -245,7 +240,7 @@ public class ConsoleRestV2UnitTest {
 	
 	@Test
 	void testSupportRequest() {
-		SupportRestService supportRestService = Mockito.spy(new SupportRestService());
+		SupportRestService supportRestService = spy(new SupportRestService());
 		
 		SupportRequest supportRequest = new SupportRequest();
 		supportRequest.setEmail("fromci@gmail.com");
@@ -255,10 +250,10 @@ public class ConsoleRestV2UnitTest {
 		
 		ServerSettings serverSettings = new ServerSettings();
 		serverSettings.setLicenceKey("license-key");
-		Mockito.doReturn(serverSettings).when(supportRestService).getServerSettings();
+		doReturn(serverSettings).when(supportRestService).getServerSettings();
 		
 		StatsCollector collector = new StatsCollector();
-		Mockito.doReturn(collector).when(supportRestService).getStatsCollector();
+		doReturn(collector).when(supportRestService).getStatsCollector();
 		
 		Result result = supportRestService.sendSupportRequest(supportRequest);
 		assertTrue(result.isSuccess());
@@ -266,21 +261,20 @@ public class ConsoleRestV2UnitTest {
 
 	@Test
 	void testSendInfo() {
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
+		RestServiceV2 restServiceSpy = spy(restService);
 
-		Mockito.doReturn(new ServerSettings()).when(restServiceSpy).getServerSettings();
+		doReturn(new ServerSettings()).when(restServiceSpy).getServerSettings();
 
 		Awaitility.await().atMost(10, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(() -> {
 			HashMap<String,String> appNameUserTypeMap = new HashMap<>();
 			appNameUserTypeMap.put("system", UserType.ADMIN.toString());
-			boolean sendUserInfo = restServiceSpy.sendUserInfo("test@antmedia.io", "firstname", "lastname","system","admin", appNameUserTypeMap);
-			return sendUserInfo;
+			return restServiceSpy.sendUserInfo("test@antmedia.io", "firstname", "lastname","system","admin", appNameUserTypeMap);
 		});
 	}
 
 	@Test
 	void testGetStatsCollector() {
-		IStatsCollector statsCollector = Mockito.mock(IStatsCollector.class);
+		IStatsCollector statsCollector = mock(IStatsCollector.class);
 
 		restService.setStatsCollector(statsCollector);
 
@@ -290,7 +284,7 @@ public class ConsoleRestV2UnitTest {
 
 	@Test
 	void testGetServerSettingsInternal() {
-		ServerSettings serverSettings = Mockito.mock(ServerSettings.class);
+		ServerSettings serverSettings = mock(ServerSettings.class);
 
 		restService.setServerSettings(serverSettings);
 
@@ -301,7 +295,7 @@ public class ConsoleRestV2UnitTest {
 
 	@Test
 	void testGetLicenseService() {
-		ILicenceService licenceService = Mockito.mock(ILicenceService.class);
+		ILicenceService licenceService = mock(ILicenceService.class);
 		assertNull(restService.getLicenceStatus());
 		assertNull(restService.getLicenceStatus("licence-key"));
 
@@ -313,7 +307,7 @@ public class ConsoleRestV2UnitTest {
 
 	@Test
 	void testGetApplication() {
-		AdminApplication application = Mockito.mock(AdminApplication.class);
+		AdminApplication application = mock(AdminApplication.class);
 
 		restService.setApplication(application);
 
@@ -323,8 +317,8 @@ public class ConsoleRestV2UnitTest {
 
 	@Test
 	void testDataStoreFactory() {
-		ConsoleDataStoreFactory dataStoreFactory = Mockito.mock(ConsoleDataStoreFactory.class);
-		Mockito.when(dataStoreFactory.getDataStore()).thenReturn(dbStore);
+		ConsoleDataStoreFactory dataStoreFactory = mock(ConsoleDataStoreFactory.class);
+		when(dataStoreFactory.getDataStore()).thenReturn(dbStore);
 
 		restService.setDataStoreFactory(dataStoreFactory);
 
@@ -335,14 +329,14 @@ public class ConsoleRestV2UnitTest {
 
 	@Test
 	void testIsClusterMode() {
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
+		RestServiceV2 restServiceSpy = spy(restService);
 
-		Mockito.doReturn(null).when(restServiceSpy).getContext();
+		doReturn(null).when(restServiceSpy).getContext();
 		assertFalse(restServiceSpy.isClusterMode());
 
-		WebApplicationContext context = Mockito.mock(WebApplicationContext.class);
-		Mockito.doReturn(context).when(restServiceSpy).getContext();
-		Mockito.when(context.containsBean(Mockito.anyString())).thenReturn(true);
+		WebApplicationContext context = mock(WebApplicationContext.class);
+		doReturn(context).when(restServiceSpy).getContext();
+		when(context.containsBean(anyString())).thenReturn(true);
 		assertTrue(restServiceSpy.isClusterMode());
 
 	}
@@ -359,166 +353,166 @@ public class ConsoleRestV2UnitTest {
 			}
 
 			{
-				RestServiceV2 restServiceSpy = Mockito.spy(restService);
+				RestServiceV2 restServiceSpy = spy(restService);
 
 				List<String> apps = new ArrayList<>();
 				apps.add("tahirrrr");
-				AdminApplication adminApp = Mockito.mock(AdminApplication.class);
-				Mockito.when(adminApp.getApplications()).thenReturn(apps);
-				IScope rootScope = Mockito.mock(IScope.class);
+				AdminApplication adminApp = mock(AdminApplication.class);
+				when(adminApp.getApplications()).thenReturn(apps);
+				IScope rootScope = mock(IScope.class);
 				String appName = "taso";
 				
-				Mockito.when(rootScope.getScope(appName)).thenReturn(Mockito.mock(IScope.class));
-				Mockito.when(adminApp.getRootScope()).thenReturn(rootScope);
+				when(rootScope.getScope(appName)).thenReturn(mock(IScope.class));
+				when(adminApp.getRootScope()).thenReturn(rootScope);
 
-				Mockito.doReturn(adminApp).when(restServiceSpy).getApplication();
-				Mockito.doReturn(false).when(restServiceSpy).isClusterMode();
-				Mockito.doReturn(Mockito.mock(AppSettings.class)).when(restServiceSpy).getSettings(appName);
-				Mockito.doReturn("").when(restServiceSpy).changeSettings(anyString(), any());
+				doReturn(adminApp).when(restServiceSpy).getApplication();
+				doReturn(false).when(restServiceSpy).isClusterMode();
+				doReturn(mock(AppSettings.class)).when(restServiceSpy).getSettings(appName);
+				doReturn("").when(restServiceSpy).changeSettings(anyString(), any());
 
-				Mockito.doReturn(false).when(restServiceSpy).isApplicationExists(appName);
+				doReturn(false).when(restServiceSpy).isApplicationExists(appName);
 
 				restServiceSpy.createApplication(appName, inputStream);
 
-				Mockito.verify(adminApp).createApplication(appName, tmpsDirectory + "taso.war");
+				verify(adminApp).createApplication(appName, tmpsDirectory + "taso.war");
 			}
 			
 			{
 				
-				RestServiceV2 restServiceSpy = Mockito.spy(restService);
+				RestServiceV2 restServiceSpy = spy(restService);
 
-				AdminApplication adminApp = Mockito.mock(AdminApplication.class);
-				IScope rootScope = Mockito.mock(IScope.class);
+				AdminApplication adminApp = mock(AdminApplication.class);
+				IScope rootScope = mock(IScope.class);
 				String appName = "taso";
 				
-				Mockito.when(rootScope.getScope(appName)).thenReturn(Mockito.mock(IScope.class));
-				Mockito.when(adminApp.getRootScope()).thenReturn(rootScope);
-				Mockito.doReturn(true).when(adminApp).createApplication(Mockito.anyString(), Mockito.anyString());
+				when(rootScope.getScope(appName)).thenReturn(mock(IScope.class));
+				when(adminApp.getRootScope()).thenReturn(rootScope);
+				doReturn(true).when(adminApp).createApplication(anyString(), anyString());
 
-				Mockito.doReturn(adminApp).when(restServiceSpy).getApplication();
-				Mockito.doReturn(false).when(restServiceSpy).isClusterMode();
+				doReturn(adminApp).when(restServiceSpy).getApplication();
+				doReturn(false).when(restServiceSpy).isClusterMode();
 				
-				Mockito.doReturn(false).when(restServiceSpy).isApplicationExists(appName);
+				doReturn(false).when(restServiceSpy).isApplicationExists(appName);
 				
-				Mockito.doReturn(Mockito.mock(AppSettings.class)).when(restServiceSpy).getSettings(appName);
-				Mockito.doReturn("").when(restServiceSpy).changeSettings(anyString(), any());
+				doReturn(mock(AppSettings.class)).when(restServiceSpy).getSettings(appName);
+				doReturn("").when(restServiceSpy).changeSettings(anyString(), any());
 
 
 				Result result = restServiceSpy.createApplication(appName, inputStream);
 
 				assertTrue(result.isSuccess());
-				Mockito.verify(adminApp).createApplication(appName, tmpsDirectory + "taso.war");
+				verify(adminApp).createApplication(appName, tmpsDirectory + "taso.war");
 				
 				
-				Mockito.doReturn(true).when(adminApp).createApplication(Mockito.anyString(), Mockito.anyString());
-				Mockito.when(rootScope.getScope(appName)).thenReturn(null);
+				doReturn(true).when(adminApp).createApplication(anyString(), anyString());
+				when(rootScope.getScope(appName)).thenReturn(null);
 				result = restServiceSpy.createApplication(appName, inputStream);
 				assertFalse(result.isSuccess());
-				Mockito.verify(adminApp, times(2)).createApplication(appName, tmpsDirectory + "taso.war");
+				verify(adminApp, times(2)).createApplication(appName, tmpsDirectory + "taso.war");
 				
 			}
 
 			{
-				RestServiceV2 restServiceSpy = Mockito.spy(restService);
+				RestServiceV2 restServiceSpy = spy(restService);
 
 				List<String> apps = new ArrayList<>();
 				apps.add("tahirrrr");
-				AdminApplication adminApp = Mockito.mock(AdminApplication.class);
-				Mockito.when(adminApp.getApplications()).thenReturn(apps);
+				AdminApplication adminApp = mock(AdminApplication.class);
+				when(adminApp.getApplications()).thenReturn(apps);
 
-				Mockito.doReturn(adminApp).when(restServiceSpy).getApplication();
-				Mockito.doReturn(false).when(restServiceSpy).isClusterMode();
-				IScope rootScope = Mockito.mock(IScope.class);
+				doReturn(adminApp).when(restServiceSpy).getApplication();
+				doReturn(false).when(restServiceSpy).isClusterMode();
+				IScope rootScope = mock(IScope.class);
 				String appName = "taso";
 				
-				Mockito.when(rootScope.getScope(appName)).thenReturn(Mockito.mock(IScope.class));
-				Mockito.when(adminApp.getRootScope()).thenReturn(rootScope);
-				Mockito.doReturn(false).when(restServiceSpy).isApplicationExists(appName);
-				Mockito.doReturn(Mockito.mock(AppSettings.class)).when(restServiceSpy).getSettings(appName);
-				Mockito.doReturn("").when(restServiceSpy).changeSettings(anyString(), any());
+				when(rootScope.getScope(appName)).thenReturn(mock(IScope.class));
+				when(adminApp.getRootScope()).thenReturn(rootScope);
+				doReturn(false).when(restServiceSpy).isApplicationExists(appName);
+				doReturn(mock(AppSettings.class)).when(restServiceSpy).getSettings(appName);
+				doReturn("").when(restServiceSpy).changeSettings(anyString(), any());
 
 
 				restServiceSpy.createApplication(appName, null);
 
-				Mockito.verify(adminApp).createApplication(appName, null);
+				verify(adminApp).createApplication(appName, null);
 			}
 
 
 			{
-				RestServiceV2 restServiceSpy = Mockito.spy(restService);
+				RestServiceV2 restServiceSpy = spy(restService);
 
 				List<String> apps = new ArrayList<>();
 				apps.add("LiveApp");
-				AdminApplication adminApp = Mockito.mock(AdminApplication.class);
-				Mockito.when(adminApp.getApplications()).thenReturn(apps);
+				AdminApplication adminApp = mock(AdminApplication.class);
+				when(adminApp.getApplications()).thenReturn(apps);
 
-				Mockito.doReturn(adminApp).when(restServiceSpy).getApplication();
-				Mockito.doReturn(false).when(restServiceSpy).isClusterMode();
+				doReturn(adminApp).when(restServiceSpy).getApplication();
+				doReturn(false).when(restServiceSpy).isClusterMode();
 				String appName = "LiveApp";
-				IScope rootScope = Mockito.mock(IScope.class);
-				Mockito.when(rootScope.getScope(appName)).thenReturn(Mockito.mock(IScope.class));
-				Mockito.when(adminApp.getRootScope()).thenReturn(rootScope);
-				Mockito.doReturn(false).when(restServiceSpy).isApplicationExists(appName);
+				IScope rootScope = mock(IScope.class);
+				when(rootScope.getScope(appName)).thenReturn(mock(IScope.class));
+				when(adminApp.getRootScope()).thenReturn(rootScope);
+				doReturn(false).when(restServiceSpy).isApplicationExists(appName);
 				
-				Mockito.doReturn(Mockito.mock(AppSettings.class)).when(restServiceSpy).getSettings(appName);
-				Mockito.doReturn("").when(restServiceSpy).changeSettings(anyString(), any());
+				doReturn(mock(AppSettings.class)).when(restServiceSpy).getSettings(appName);
+				doReturn("").when(restServiceSpy).changeSettings(anyString(), any());
 
 
 				restServiceSpy.createApplication(appName, inputStream);
 
-				Mockito.verify(adminApp, Mockito.never()).createApplication(appName, appName + ".war");
+				verify(adminApp, never()).createApplication(appName, appName + ".war");
 			}
 
 			{
-				RestServiceV2 restServiceSpy = Mockito.spy(restService);
+				RestServiceV2 restServiceSpy = spy(restService);
 				ServerSettings settings = new ServerSettings();
 
 				List<String> apps = new ArrayList<>();
 				apps.add("tahirrrr");
-				AdminApplication adminApp = Mockito.mock(AdminApplication.class);
-				Mockito.when(adminApp.getApplications()).thenReturn(apps);
-				IClusterNotifier clusterNotifier = Mockito.mock(IClusterNotifier.class);
-				IClusterStore clusterStore = Mockito.mock(IClusterStore.class);
+				AdminApplication adminApp = mock(AdminApplication.class);
+				when(adminApp.getApplications()).thenReturn(apps);
+				IClusterNotifier clusterNotifier = mock(IClusterNotifier.class);
+				IClusterStore clusterStore = mock(IClusterStore.class);
 
-				Mockito.when(adminApp.getClusterNotifier()).thenReturn(clusterNotifier);
-				Mockito.when(clusterNotifier.getClusterStore()).thenReturn(clusterStore);
-				Mockito.when(clusterStore.saveSettings(Mockito.any())).thenReturn(true);
+				when(adminApp.getClusterNotifier()).thenReturn(clusterNotifier);
+				when(clusterNotifier.getClusterStore()).thenReturn(clusterStore);
+				when(clusterStore.saveSettings(any())).thenReturn(true);
 
 
 
-				Mockito.doReturn(adminApp).when(restServiceSpy).getApplication();
-				Mockito.doReturn(true).when(restServiceSpy).isClusterMode();
-				Mockito.doReturn(settings).when(restServiceSpy).getServerSettings();
+				doReturn(adminApp).when(restServiceSpy).getApplication();
+				doReturn(true).when(restServiceSpy).isClusterMode();
+				doReturn(settings).when(restServiceSpy).getServerSettings();
 				var appName = "taso";
-				IScope rootScope = Mockito.mock(IScope.class);
-				Mockito.when(rootScope.getScope(appName)).thenReturn(Mockito.mock(IScope.class));
-				Mockito.when(adminApp.getRootScope()).thenReturn(rootScope);
-				Mockito.doReturn(false).when(restServiceSpy).isApplicationExists(appName);
+				IScope rootScope = mock(IScope.class);
+				when(rootScope.getScope(appName)).thenReturn(mock(IScope.class));
+				when(adminApp.getRootScope()).thenReturn(rootScope);
+				doReturn(false).when(restServiceSpy).isApplicationExists(appName);
 				
-				Mockito.doReturn(Mockito.mock(AppSettings.class)).when(restServiceSpy).getSettings(appName);
-				Mockito.doReturn("").when(restServiceSpy).changeSettings(anyString(), any());
+				doReturn(mock(AppSettings.class)).when(restServiceSpy).getSettings(appName);
+				doReturn("").when(restServiceSpy).changeSettings(anyString(), any());
 
 				
 
 				restServiceSpy.createApplication(appName, inputStream);
 
-				Mockito.verify(adminApp).createApplication(appName, tmpsDirectory + appName + ".war");
+				verify(adminApp).createApplication(appName, tmpsDirectory + appName + ".war");
 			}
 
 			{
-				RestServiceV2 restServiceSpy = Mockito.spy(restService);
+				RestServiceV2 restServiceSpy = spy(restService);
 
 				List<String> apps = new ArrayList<>();
 				apps.add("LiveApp");
-				AdminApplication adminApp = Mockito.mock(AdminApplication.class);
-				Mockito.when(adminApp.getApplications()).thenReturn(apps);
+				AdminApplication adminApp = mock(AdminApplication.class);
+				when(adminApp.getApplications()).thenReturn(apps);
 
-				Mockito.doReturn(adminApp).when(restServiceSpy).getApplication();
-				Mockito.doReturn(false).when(restServiceSpy).isClusterMode();
+				doReturn(adminApp).when(restServiceSpy).getApplication();
+				doReturn(false).when(restServiceSpy).isClusterMode();
 
 				restServiceSpy.createApplication("*_?", inputStream).isSuccess();
 
-				Mockito.verify(adminApp, Mockito.never()).createApplication("*_?", "*_?.war");
+				verify(adminApp, never()).createApplication("*_?", "*_?.war");
 			}
 		}
 		catch(Exception e){
@@ -537,14 +531,14 @@ public class ConsoleRestV2UnitTest {
 		String userName = "username" + (int) (Math.random() * 100000);
 		User user = new User(userName, password, UserType.ADMIN, "all", null);
 
-		HttpSession session = Mockito.mock(HttpSession.class);
-		Mockito.when(session.getAttribute(IS_AUTHENTICATED)).thenReturn(true);
-		Mockito.when(session.getAttribute(USER_EMAIL)).thenReturn(userName);
-		Mockito.when(session.getAttribute(USER_PASSWORD)).thenReturn(password);
+		HttpSession session = mock(HttpSession.class);
+		when(session.getAttribute(IS_AUTHENTICATED)).thenReturn(true);
+		when(session.getAttribute(USER_EMAIL)).thenReturn(userName);
+		when(session.getAttribute(USER_PASSWORD)).thenReturn(password);
 
-		HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
 
-		Mockito.when(mockRequest.getSession()).thenReturn(session);
+		when(mockRequest.getSession()).thenReturn(session);
 
 		restService.setRequestForTest(mockRequest);
 
@@ -592,14 +586,14 @@ public class ConsoleRestV2UnitTest {
 		String userName = "username" + (int) (Math.random() * 100000);
 		User user = new User(userName, password, UserType.ADMIN, "system", null);
 
-		HttpSession session = Mockito.mock(HttpSession.class);
-		Mockito.when(session.getAttribute(IS_AUTHENTICATED)).thenReturn(true);
-		Mockito.when(session.getAttribute(USER_EMAIL)).thenReturn(userName);
-		Mockito.when(session.getAttribute(USER_PASSWORD)).thenReturn(password);
+		HttpSession session = mock(HttpSession.class);
+		when(session.getAttribute(IS_AUTHENTICATED)).thenReturn(true);
+		when(session.getAttribute(USER_EMAIL)).thenReturn(userName);
+		when(session.getAttribute(USER_PASSWORD)).thenReturn(password);
 
-		HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
 
-		Mockito.when(mockRequest.getSession()).thenReturn(session);
+		when(mockRequest.getSession()).thenReturn(session);
 
 		restService.setRequestForTest(mockRequest);
 
@@ -636,16 +630,16 @@ public class ConsoleRestV2UnitTest {
 	
 	@Test
 	void testInvalidateSession() {
-		HttpSession session = Mockito.mock(HttpSession.class);
-		HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+		HttpSession session = mock(HttpSession.class);
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
 
-		Mockito.when(mockRequest.getSession()).thenReturn(session);
+		when(mockRequest.getSession()).thenReturn(session);
 		restService.setRequestForTest(mockRequest);
 
 		
 		restService.deleteSession();
 		
-		Mockito.verify(session).invalidate();
+		verify(session).invalidate();
 		
 		
 	}
@@ -656,14 +650,14 @@ public class ConsoleRestV2UnitTest {
 		String userName = "username" + (int) (Math.random() * 100000);
 		User user = new User(userName, password, UserType.ADMIN, "all", null);
 
-		HttpSession session = Mockito.mock(HttpSession.class);
-		Mockito.when(session.getAttribute(IS_AUTHENTICATED)).thenReturn(true);
-		Mockito.when(session.getAttribute(USER_EMAIL)).thenReturn(userName);
-		Mockito.when(session.getAttribute(USER_PASSWORD)).thenReturn(password);
+		HttpSession session = mock(HttpSession.class);
+		when(session.getAttribute(IS_AUTHENTICATED)).thenReturn(true);
+		when(session.getAttribute(USER_EMAIL)).thenReturn(userName);
+		when(session.getAttribute(USER_PASSWORD)).thenReturn(password);
 
-		HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
 
-		Mockito.when(mockRequest.getSession()).thenReturn(session);
+		when(mockRequest.getSession()).thenReturn(session);
 
 		restService.setRequestForTest(mockRequest);
 
@@ -694,28 +688,28 @@ public class ConsoleRestV2UnitTest {
 	@Test
 	void testDeleteApplication() {
 
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
+		RestServiceV2 restServiceSpy = spy(restService);
 
-		AntMediaApplicationAdapter adapter = Mockito.mock(AntMediaApplicationAdapter.class);
-		Mockito.doReturn(adapter).when(restServiceSpy).getAppAdaptor(Mockito.any());
-		Mockito.when(adapter.getAppSettings()).thenReturn(Mockito.mock(AppSettings.class));
+		AntMediaApplicationAdapter adapter = mock(AntMediaApplicationAdapter.class);
+		doReturn(adapter).when(restServiceSpy).getAppAdaptor(any());
+		when(adapter.getAppSettings()).thenReturn(mock(AppSettings.class));
 
-		AdminApplication adminApp = Mockito.mock(AdminApplication.class);
+		AdminApplication adminApp = mock(AdminApplication.class);
 
-		Mockito.doReturn(adminApp).when(restServiceSpy).getApplication();
-		Mockito.doReturn("").when(restServiceSpy).changeSettings(Mockito.any(), Mockito.any());
-		Mockito.doReturn(false).when(restServiceSpy).isClusterMode();
+		doReturn(adminApp).when(restServiceSpy).getApplication();
+		doReturn("").when(restServiceSpy).changeSettings(any(), any());
+		doReturn(false).when(restServiceSpy).isClusterMode();
 
 		Result result = restServiceSpy.deleteApplication("test", true);
 		assertFalse(result.isSuccess());
 
 
-		Mockito.when(adminApp.deleteApplication(Mockito.anyString(),Mockito.eq(true))).thenReturn(true);
+		when(adminApp.deleteApplication(anyString(), eq(true))).thenReturn(true);
 		result = restServiceSpy.deleteApplication("test", true);
 		assertTrue(result.isSuccess());
 
 
-		Mockito.doReturn(null).when(restServiceSpy).getAppAdaptor(Mockito.any());
+		doReturn(null).when(restServiceSpy).getAppAdaptor(any());
 		result = restServiceSpy.deleteApplication("test", true);
 		assertFalse(result.isSuccess());
 		
@@ -727,12 +721,12 @@ public class ConsoleRestV2UnitTest {
 
 	@Test
 	void testLiveness() {
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
+		RestServiceV2 restServiceSpy = spy(restService);
 
 		Response liveness = restServiceSpy.liveness();
 		assertEquals(Status.OK.getStatusCode(), liveness.getStatus());
 
-		Mockito.doReturn(null).when(restServiceSpy).getHostname();
+		doReturn(null).when(restServiceSpy).getHostname();
 
 		liveness = restServiceSpy.liveness();
 		assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), liveness.getStatus());
@@ -740,38 +734,38 @@ public class ConsoleRestV2UnitTest {
 
 	@Test
 	void testResetBroadcast() {
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
+		RestServiceV2 restServiceSpy = spy(restService);
 
-		AntMediaApplicationAdapter adapter = Mockito.mock(AntMediaApplicationAdapter.class);
-		AdminApplication adminApp = Mockito.mock(AdminApplication.class);
-		Mockito.doReturn(adminApp).when(restServiceSpy).getApplication();
+		AntMediaApplicationAdapter adapter = mock(AntMediaApplicationAdapter.class);
+		AdminApplication adminApp = mock(AdminApplication.class);
+		doReturn(adminApp).when(restServiceSpy).getApplication();
 
 		restServiceSpy.resetBroadcast("junit");
-		Mockito.verify(adapter, Mockito.never()).resetBroadcasts();
+		verify(adapter, never()).resetBroadcasts();
 
-		ApplicationContext appContext = Mockito.mock(ApplicationContext.class);
-		Mockito.when(adminApp.getApplicationContext(Mockito.any())).thenReturn(appContext);
+		ApplicationContext appContext = mock(ApplicationContext.class);
+		when(adminApp.getApplicationContext(any())).thenReturn(appContext);
 		restServiceSpy.resetBroadcast("junit");
-		Mockito.verify(adapter, Mockito.never()).resetBroadcasts();
+		verify(adapter, never()).resetBroadcasts();
 
 
-		Mockito.when(appContext.getBean(Mockito.anyString())).thenReturn(adapter);
+		when(appContext.getBean(anyString())).thenReturn(adapter);
 		restServiceSpy.resetBroadcast("junit");
-		Mockito.verify(adapter).resetBroadcasts();
+		verify(adapter).resetBroadcasts();
 
 
 	}
 
 	@Test
 	void testShutDownStatus() {
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
-		AntMediaApplicationAdapter adaptor = Mockito.mock(AntMediaApplicationAdapter.class);
+		RestServiceV2 restServiceSpy = spy(restService);
+		AntMediaApplicationAdapter adaptor = mock(AntMediaApplicationAdapter.class);
 
-		Mockito.doReturn(adaptor).when(restServiceSpy).getAppAdaptor("app1");
-		Mockito.doReturn(null).when(restServiceSpy).getAppAdaptor("app2");
+		doReturn(adaptor).when(restServiceSpy).getAppAdaptor("app1");
+		doReturn(null).when(restServiceSpy).getAppAdaptor("app2");
 		restServiceSpy.setShutdownStatus("app1,app2");
 
-		Mockito.verify(adaptor).setShutdownProperly(true);
+		verify(adaptor).setShutdownProperly(true);
 	}
 
 	@Test
@@ -802,7 +796,7 @@ public class ConsoleRestV2UnitTest {
 	void testTriggerGC() {
 		//just increase coverage and make sure that method is there.
 		//It's better to check if it calls System.gc. We may add it later with Powermockito. It's good enough at this stage 
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
+		RestServiceV2 restServiceSpy = spy(restService);
 		Result result = restServiceSpy.triggerGc();
 		assertTrue(result.isSuccess());
 	}
@@ -810,50 +804,50 @@ public class ConsoleRestV2UnitTest {
 	@Test
 	void testConfigureSSL()
 	{
-		RestServiceV2 restServiceSpy = Mockito.spy(restService);
-		AdminApplication adminApp = Mockito.mock(AdminApplication.class);
-		Mockito.doReturn(adminApp).when(restServiceSpy).getApplication();
-		Mockito.when(adminApp.runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class))).thenReturn(true);
+		RestServiceV2 restServiceSpy = spy(restService);
+		AdminApplication adminApp = mock(AdminApplication.class);
+		doReturn(adminApp).when(restServiceSpy).getApplication();
+		when(adminApp.runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class))).thenReturn(true);
 
 		Result result = restServiceSpy.configureSsl(null, null, null, null, null, null, null, null);
 		assertFalse(result.isSuccess());
-		Mockito.verify(adminApp, Mockito.never()).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+		verify(adminApp, never()).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 
 		result = restServiceSpy.configureSsl(null, "", null, null, null, null, null, null);
 		assertFalse(result.isSuccess());
-		Mockito.verify(adminApp, Mockito.never()).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+		verify(adminApp, never()).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 
 		result = restServiceSpy.configureSsl("", "", null, null, null, null, null, null);
 		assertFalse(result.isSuccess());
-		Mockito.verify(adminApp, Mockito.never()).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+		verify(adminApp, never()).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 		
 		result = restServiceSpy.configureSsl("example.com", "", null, null, null, null, null, null);
 		assertFalse(result.isSuccess());
-		Mockito.verify(adminApp, Mockito.never()).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+		verify(adminApp, never()).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 
 
 		result = restServiceSpy.configureSsl("", "ANTMEDIA_SUBDOMAIN", null, null, null, null, null, null);
 		assertTrue(result.isSuccess());
-		Mockito.verify(adminApp, Mockito.times(1)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+		verify(adminApp, times(1)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 
 
 		result = restServiceSpy.configureSsl("", "CUSTOM_DOMAIN", null, null, null, null, null, null);
 		assertFalse(result.isSuccess());
-		Mockito.verify(adminApp, Mockito.times(1)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+		verify(adminApp, times(1)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 
 		result = restServiceSpy.configureSsl("http://example.com", "CUSTOM_DOMAIN", null, null, null, null, null, null);
 		assertTrue(result.isSuccess());
-		Mockito.verify(adminApp, Mockito.times(2)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+		verify(adminApp, times(2)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 
 		//ignores the given domain name
 		result = restServiceSpy.configureSsl("http://example.com", "ANTMEDIA_SUBDOMAIN", null, null, null, null, null, null);
 		assertTrue(result.isSuccess());
-		Mockito.verify(adminApp, Mockito.times(3)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+		verify(adminApp, times(3)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 
 
 		result = restServiceSpy.configureSsl("http://example.com", "CUSTOM_CERTIFICATE", null, null, null, null, null, null);
 		assertFalse(result.isSuccess());
-		Mockito.verify(adminApp, Mockito.times(3)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+		verify(adminApp, times(3)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 
 		try {
 				
@@ -861,23 +855,23 @@ public class ConsoleRestV2UnitTest {
 
 			result = restServiceSpy.configureSsl("http://example.com", "CUSTOM_CERTIFICATE", fullChainInputStream, null, null, null, null, null);
 			assertFalse(result.isSuccess());
-			Mockito.verify(adminApp, Mockito.times(3)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+			verify(adminApp, times(3)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 			
-			FormDataContentDisposition fullChainFileContent = Mockito.mock(FormDataContentDisposition.class);
-			Mockito.when(fullChainFileContent.getFileName()).thenReturn(null);
+			FormDataContentDisposition fullChainFileContent = mock(FormDataContentDisposition.class);
+			when(fullChainFileContent.getFileName()).thenReturn(null);
 			result = restServiceSpy.configureSsl("http://example.com", "CUSTOM_CERTIFICATE", fullChainInputStream, fullChainFileContent, null, null, null, null);
 			assertFalse(result.isSuccess());
-			Mockito.verify(adminApp, Mockito.times(3)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+			verify(adminApp, times(3)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 			
-			Mockito.when(fullChainFileContent.getFileName()).thenReturn("");
+			when(fullChainFileContent.getFileName()).thenReturn("");
 			result = restServiceSpy.configureSsl("http://example.com", "CUSTOM_CERTIFICATE", fullChainInputStream, fullChainFileContent, null, null, null, null);
 			assertFalse(result.isSuccess());
-			Mockito.verify(adminApp, Mockito.times(3)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+			verify(adminApp, times(3)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 			
-			Mockito.when(fullChainFileContent.getFileName()).thenReturn("fullchain.pem");
+			when(fullChainFileContent.getFileName()).thenReturn("fullchain.pem");
 			result = restServiceSpy.configureSsl("http://example.com", "CUSTOM_CERTIFICATE", fullChainInputStream, fullChainFileContent, null, null, null, null);
 			assertFalse(result.isSuccess());
-			Mockito.verify(adminApp, Mockito.times(3)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+			verify(adminApp, times(3)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 			
 			
 			//private key file
@@ -885,23 +879,23 @@ public class ConsoleRestV2UnitTest {
 
 			result = restServiceSpy.configureSsl("http://example.com", "CUSTOM_CERTIFICATE", fullChainInputStream, fullChainFileContent, privateKeyFileInputStream, null, null, null);
 			assertFalse(result.isSuccess());
-			Mockito.verify(adminApp, Mockito.times(3)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+			verify(adminApp, times(3)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 			
-			FormDataContentDisposition privateFileContent = Mockito.mock(FormDataContentDisposition.class);
-			Mockito.when(privateFileContent.getFileName()).thenReturn(null);
+			FormDataContentDisposition privateFileContent = mock(FormDataContentDisposition.class);
+			when(privateFileContent.getFileName()).thenReturn(null);
 			result = restServiceSpy.configureSsl("http://example.com", "CUSTOM_CERTIFICATE", fullChainInputStream, fullChainFileContent, privateKeyFileInputStream, privateFileContent, null, null);
 			assertFalse(result.isSuccess());
-			Mockito.verify(adminApp, Mockito.times(3)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+			verify(adminApp, times(3)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 			
-			Mockito.when(privateFileContent.getFileName()).thenReturn("");
+			when(privateFileContent.getFileName()).thenReturn("");
 			result = restServiceSpy.configureSsl("http://example.com", "CUSTOM_CERTIFICATE", fullChainInputStream, fullChainFileContent, privateKeyFileInputStream, privateFileContent, null, null);
 			assertFalse(result.isSuccess());
-			Mockito.verify(adminApp, Mockito.times(3)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+			verify(adminApp, times(3)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 			
-			Mockito.when(privateFileContent.getFileName()).thenReturn("fullchain.pem");
+			when(privateFileContent.getFileName()).thenReturn("fullchain.pem");
 			result = restServiceSpy.configureSsl("http://example.com", "CUSTOM_CERTIFICATE", fullChainInputStream, fullChainFileContent, privateKeyFileInputStream, privateFileContent, null, null);
 			assertFalse(result.isSuccess());
-			Mockito.verify(adminApp, Mockito.times(3)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+			verify(adminApp, times(3)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 		
 			
 			//chain file
@@ -910,23 +904,23 @@ public class ConsoleRestV2UnitTest {
 
 			result = restServiceSpy.configureSsl("http://example.com", "CUSTOM_CERTIFICATE", fullChainInputStream, fullChainFileContent, privateKeyFileInputStream, privateFileContent, chainFileInputStream, null);
 			assertFalse(result.isSuccess());
-			Mockito.verify(adminApp, Mockito.times(3)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+			verify(adminApp, times(3)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 			
-			FormDataContentDisposition chainFileContent = Mockito.mock(FormDataContentDisposition.class);
-			Mockito.when(chainFileContent.getFileName()).thenReturn(null);
+			FormDataContentDisposition chainFileContent = mock(FormDataContentDisposition.class);
+			when(chainFileContent.getFileName()).thenReturn(null);
 			result = restServiceSpy.configureSsl("http://example.com", "CUSTOM_CERTIFICATE", fullChainInputStream, fullChainFileContent, privateKeyFileInputStream, privateFileContent, chainFileInputStream, chainFileContent);
 			assertFalse(result.isSuccess());
-			Mockito.verify(adminApp, Mockito.times(3)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+			verify(adminApp, times(3)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 			
-			Mockito.when(chainFileContent.getFileName()).thenReturn("");
+			when(chainFileContent.getFileName()).thenReturn("");
 			result = restServiceSpy.configureSsl("http://example.com", "CUSTOM_CERTIFICATE", fullChainInputStream, fullChainFileContent, privateKeyFileInputStream, privateFileContent, chainFileInputStream, chainFileContent);
 			assertFalse(result.isSuccess());
-			Mockito.verify(adminApp, Mockito.times(3)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+			verify(adminApp, times(3)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 			
-			Mockito.when(chainFileContent.getFileName()).thenReturn("fullchain.pem");
+			when(chainFileContent.getFileName()).thenReturn("fullchain.pem");
 			result = restServiceSpy.configureSsl("http://example.com", "CUSTOM_CERTIFICATE", fullChainInputStream, fullChainFileContent, privateKeyFileInputStream, privateFileContent, chainFileInputStream, chainFileContent);
 			assertTrue(result.isSuccess());
-			Mockito.verify(adminApp, Mockito.times(4)).runConfiguredCommand(Mockito.eq(AdminApplication.ENABLE_SSL_COMMAND), Mockito.any(String[].class));
+			verify(adminApp, times(4)).runConfiguredCommand(eq(AdminApplication.ENABLE_SSL_COMMAND), any(String[].class));
 			
 			
 			
@@ -953,14 +947,14 @@ public class ConsoleRestV2UnitTest {
 		User user = new User(userName, CommonRestService.getMD5Hash(password), null, null, appNameUserTypeMap);
 		dbStore.addUser(user);
 
-		HttpSession session = Mockito.mock(HttpSession.class);
+		HttpSession session = mock(HttpSession.class);
 
-		Mockito.when(session.getAttribute(USER_EMAIL)).thenReturn(userName);
-		Mockito.when(session.getAttribute(USER_PASSWORD)).thenReturn(password);
+		when(session.getAttribute(USER_EMAIL)).thenReturn(userName);
+		when(session.getAttribute(USER_PASSWORD)).thenReturn(password);
 
-		HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
 
-		Mockito.when(mockRequest.getSession()).thenReturn(session);
+		when(mockRequest.getSession()).thenReturn(session);
 
 		restService.setRequestForTest(mockRequest);
 
@@ -986,44 +980,41 @@ public class ConsoleRestV2UnitTest {
 		try{
 			inputStream = new FileInputStream("src/test/resources/sample_MP4_480.mp4");
 			String tmpsDirectory = System.getProperty("java.io.tmpdir");
-			if (!tmpsDirectory.endsWith("/")) {
-				tmpsDirectory += "/";
-			}
 
 			AppSettings appSettings = new AppSettings();
 
-			RestServiceV2 restServiceSpy = Mockito.spy(restService);
+			RestServiceV2 restServiceSpy = spy(restService);
 
-			AdminApplication adminApp = Mockito.mock(AdminApplication.class);
-			IScope rootScope = Mockito.mock(IScope.class);
+			AdminApplication adminApp = mock(AdminApplication.class);
+			IScope rootScope = mock(IScope.class);
 			String appName = "testapp";
 
-			IClusterNotifier clusterNotifier = Mockito.mock(IClusterNotifier.class);
-			IClusterStore clusterStore = Mockito.mock(IClusterStore.class);
-			Mockito.when(clusterNotifier.getClusterStore()).thenReturn(clusterStore);
-			Mockito.when(adminApp.getClusterNotifier()).thenReturn(clusterNotifier);
+			IClusterNotifier clusterNotifier = mock(IClusterNotifier.class);
+			IClusterStore clusterStore = mock(IClusterStore.class);
+			when(clusterNotifier.getClusterStore()).thenReturn(clusterStore);
+			when(adminApp.getClusterNotifier()).thenReturn(clusterNotifier);
 
-			Mockito.when(rootScope.getScope(appName)).thenReturn(Mockito.mock(IScope.class));
-			Mockito.when(adminApp.getRootScope()).thenReturn(rootScope);
-			Mockito.doReturn(true).when(adminApp).createApplication(Mockito.anyString(), Mockito.anyString());
-			Mockito.doReturn(true).when(adminApp).deleteApplication(Mockito.anyString(), Mockito.anyBoolean());
+			when(rootScope.getScope(appName)).thenReturn(mock(IScope.class));
+			when(adminApp.getRootScope()).thenReturn(rootScope);
+			doReturn(true).when(adminApp).createApplication(anyString(), anyString());
+			doReturn(true).when(adminApp).deleteApplication(anyString(), anyBoolean());
 
 
-			Mockito.doReturn(adminApp).when(restServiceSpy).getApplication();
-			Mockito.doReturn(true).when(restServiceSpy).isClusterMode();
-			Mockito.doReturn(false).when(restServiceSpy).isApplicationExists(appName);
-			Mockito.doReturn(Mockito.mock(ServerSettings.class)).when(restServiceSpy).getServerSettings();
-			Mockito.doReturn(appSettings).when(restServiceSpy).getSettings(appName);
-			Mockito.doReturn("").when(restServiceSpy).changeSettings(Mockito.eq(appName), any());
+			doReturn(adminApp).when(restServiceSpy).getApplication();
+			doReturn(true).when(restServiceSpy).isClusterMode();
+			doReturn(false).when(restServiceSpy).isApplicationExists(appName);
+			doReturn(mock(ServerSettings.class)).when(restServiceSpy).getServerSettings();
+			doReturn(appSettings).when(restServiceSpy).getSettings(appName);
+			doReturn("").when(restServiceSpy).changeSettings(eq(appName), any());
 
 			Result result = restServiceSpy.createApplication(appName, inputStream);
 
 			ArgumentCaptor<AppSettings> appSettingsArgumentCaptor = ArgumentCaptor.forClass(AppSettings.class);
-			Mockito.verify(clusterStore, times(1)).saveSettings(appSettingsArgumentCaptor.capture());
+			verify(clusterStore, times(1)).saveSettings(appSettingsArgumentCaptor.capture());
 			assertEquals(AppSettings.APPLICATION_STATUS_INSTALLING, appSettingsArgumentCaptor.getValue().getAppStatus());
 
 			ArgumentCaptor<AppSettings> appSettingsArgumentCaptor2 = ArgumentCaptor.forClass(AppSettings.class);
-			Mockito.verify(restServiceSpy, times(1)).changeSettings(Mockito.eq(appName), appSettingsArgumentCaptor2.capture());
+			verify(restServiceSpy, times(1)).changeSettings(eq(appName), appSettingsArgumentCaptor2.capture());
 			assertEquals(AppSettings.APPLICATION_STATUS_INSTALLED, appSettingsArgumentCaptor2.getValue().getAppStatus());
 
 			assertTrue(result.isSuccess());

--- a/src/test/java/io/antmedia/test/console/ConsoleRestV2UnitTest.java
+++ b/src/test/java/io/antmedia/test/console/ConsoleRestV2UnitTest.java
@@ -1,33 +1,29 @@
 package io.antmedia.test.console;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-
 import com.google.gson.JsonObject;
+import io.antmedia.AntMediaApplicationAdapter;
+import io.antmedia.AppSettings;
+import io.antmedia.cluster.IClusterNotifier;
+import io.antmedia.cluster.IClusterStore;
+import io.antmedia.console.AdminApplication;
+import io.antmedia.console.datastore.ConsoleDataStoreFactory;
+import io.antmedia.console.datastore.MapDBStore;
+import io.antmedia.console.rest.CommonRestService;
+import io.antmedia.console.rest.RestServiceV2;
+import io.antmedia.console.rest.SupportRequest;
+import io.antmedia.console.rest.SupportRestService;
+import io.antmedia.datastore.db.types.User;
+import io.antmedia.datastore.db.types.UserType;
+import io.antmedia.licence.ILicenceService;
+import io.antmedia.rest.model.Result;
+import io.antmedia.settings.ServerSettings;
+import io.antmedia.statistic.IStatsCollector;
+import io.antmedia.statistic.StatsCollector;
+import io.vertx.core.Vertx;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
-
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 import org.awaitility.Awaitility;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.junit.Rule;
@@ -43,28 +39,28 @@ import org.red5.server.api.scope.IScope;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.context.WebApplicationContext;
 
-import io.antmedia.AntMediaApplicationAdapter;
-import io.antmedia.AppSettings;
-import io.antmedia.cluster.IClusterNotifier;
-import io.antmedia.cluster.IClusterStore;
-import io.antmedia.console.AdminApplication;
-import io.antmedia.console.datastore.ConsoleDataStoreFactory;
-import io.antmedia.console.datastore.MapDBStore;
-import io.antmedia.console.rest.CommonRestService;
-import io.antmedia.console.rest.RestServiceV2;
-import io.antmedia.console.rest.SupportRequest;
-import io.antmedia.console.rest.SupportRestService;
-import io.antmedia.datastore.db.types.User;
-import io.antmedia.licence.ILicenceService;
-import io.antmedia.rest.model.Result;
-import io.antmedia.datastore.db.types.UserType;
-import io.antmedia.settings.ServerSettings;
-import io.antmedia.statistic.IStatsCollector;
-import io.antmedia.statistic.StatsCollector;
-import io.vertx.core.Vertx;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.Status;
-import org.webrtc.SessionDescription;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
 
 
 public class ConsoleRestV2UnitTest {
@@ -78,24 +74,6 @@ public class ConsoleRestV2UnitTest {
 	public static final String USER_EMAIL = "user.email";
 
 	public static final String IS_AUTHENTICATED = "isAuthenticated";
-
-	private static final int OFFSET_NOT_USED = -1;
-	private static final int MAX_OFFSET_SIZE = 10000000;
-	private static final int MAX_CHAR_SIZE = 512000;
-	private static final int MIN_CHAR_SIZE = 10;
-	private static final int MIN_OFFSET_SIZE = 10;
-	private static final String LOG_CONTENT = "logContent";
-	private static final String LOG_SIZE = "logSize";
-	private static final String LOG_CONTENT_RANGE = "logContentRange";
-	private static final float MEGABYTE = 1024f * 1024f;
-	private static final String MB_STRING = "%.2f MB";
-	private static final String LOG_TYPE_TEST = "test";
-	private static final String LOG_TYPE_RANDOM = "random";
-	private static final String TEST_LOG_LOCATION = "target/test-classes/ant-media-server.log";
-	private static final String FILE_NOT_EXIST = "There are no registered logs yet";
-	private static final String CREATED_FILE_TEXT = "2019-04-24 19:01:24,291 [main] INFO  org.red5.server.Launcher - Ant Media Server Enterprise 1.7.0-SNAPSHOT\n" +
-			"2019-04-24 19:01:24,334 [main] INFO  o.s.c.s.FileSystemXmlApplicationContext - Refreshing org.springframework.context.support.FileSystemXmlApplicationContext@f0f2775: startup date [Wed Apr 24 19:01:24 EET 2019]; root of context hierarchy";
-
 
 	@Rule
 	public TestRule watcher = new TestWatcher() {
@@ -112,7 +90,7 @@ public class ConsoleRestV2UnitTest {
 	};
 	
 	@BeforeEach
-	public void before() {
+	void before() {
 		File f = new File("server.db");
 		if (f.exists()) {
 			try {
@@ -128,7 +106,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@AfterEach
-	public void after() {
+	void after() {
 		// dbStore.clear();
 		dbStore.close();
 		vertx.close();
@@ -143,7 +121,7 @@ public class ConsoleRestV2UnitTest {
 		}
 	}
 	@Test
-	public void getUserList(){
+	void getUserList(){
 		String password = "password";
 		String userName = "username" + (int) (Math.random() * 1000000000);
 		User user = new User(userName, password, UserType.ADMIN, "all", null);
@@ -169,7 +147,7 @@ public class ConsoleRestV2UnitTest {
 
 
 	@Test
-	public void testAddUser() {
+	void testAddUser() {
 
 		String password = "password";
 		String userName = "username" + (int) (Math.random() * 1000000000);
@@ -223,7 +201,7 @@ public class ConsoleRestV2UnitTest {
 	private volatile boolean err;
 
 	@Test
-	public void testMultipleThreads() {
+	void testMultipleThreads() {
 
 		Thread thread = null;
 		err = false;
@@ -266,7 +244,7 @@ public class ConsoleRestV2UnitTest {
 	}
 	
 	@Test
-	public void testSupportRequest() {
+	void testSupportRequest() {
 		SupportRestService supportRestService = Mockito.spy(new SupportRestService());
 		
 		SupportRequest supportRequest = new SupportRequest();
@@ -287,7 +265,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testSendInfo() {
+	void testSendInfo() {
 		RestServiceV2 restServiceSpy = Mockito.spy(restService);
 
 		Mockito.doReturn(new ServerSettings()).when(restServiceSpy).getServerSettings();
@@ -301,7 +279,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testGetStatsCollector() {
+	void testGetStatsCollector() {
 		IStatsCollector statsCollector = Mockito.mock(IStatsCollector.class);
 
 		restService.setStatsCollector(statsCollector);
@@ -311,7 +289,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testGetServerSettingsInternal() {
+	void testGetServerSettingsInternal() {
 		ServerSettings serverSettings = Mockito.mock(ServerSettings.class);
 
 		restService.setServerSettings(serverSettings);
@@ -322,7 +300,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testGetLicenseService() {
+	void testGetLicenseService() {
 		ILicenceService licenceService = Mockito.mock(ILicenceService.class);
 		assertNull(restService.getLicenceStatus());
 		assertNull(restService.getLicenceStatus("licence-key"));
@@ -334,7 +312,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testGetApplication() {
+	void testGetApplication() {
 		AdminApplication application = Mockito.mock(AdminApplication.class);
 
 		restService.setApplication(application);
@@ -344,7 +322,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testDataStoreFactory() {
+	void testDataStoreFactory() {
 		ConsoleDataStoreFactory dataStoreFactory = Mockito.mock(ConsoleDataStoreFactory.class);
 		Mockito.when(dataStoreFactory.getDataStore()).thenReturn(dbStore);
 
@@ -356,7 +334,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testIsClusterMode() {
+	void testIsClusterMode() {
 		RestServiceV2 restServiceSpy = Mockito.spy(restService);
 
 		Mockito.doReturn(null).when(restServiceSpy).getContext();
@@ -371,7 +349,7 @@ public class ConsoleRestV2UnitTest {
 	
 
 	@Test
-	public void testUploadApplication(){
+	void testUploadApplication(){
 		FileInputStream inputStream;
 		try{
 			inputStream = new FileInputStream("src/test/resources/sample_MP4_480.mp4");
@@ -553,7 +531,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testChangePassword() {
+	void testChangePassword() {
 
 		String password = "password";
 		String userName = "username" + (int) (Math.random() * 100000);
@@ -608,7 +586,7 @@ public class ConsoleRestV2UnitTest {
 
 	}
 	@Test
-	public void testEditUser(){
+	void testEditUser(){
 
 		String password = "password";
 		String userName = "username" + (int) (Math.random() * 100000);
@@ -657,7 +635,7 @@ public class ConsoleRestV2UnitTest {
 	}
 	
 	@Test
-	public void testInvalidateSession() {
+	void testInvalidateSession() {
 		HttpSession session = Mockito.mock(HttpSession.class);
 		HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
 
@@ -673,7 +651,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testDeleteUser() {
+	void testDeleteUser() {
 		String password = "password";
 		String userName = "username" + (int) (Math.random() * 100000);
 		User user = new User(userName, password, UserType.ADMIN, "all", null);
@@ -714,7 +692,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testDeleteApplication() {
+	void testDeleteApplication() {
 
 		RestServiceV2 restServiceSpy = Mockito.spy(restService);
 
@@ -748,7 +726,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testLiveness() {
+	void testLiveness() {
 		RestServiceV2 restServiceSpy = Mockito.spy(restService);
 
 		Response liveness = restServiceSpy.liveness();
@@ -761,7 +739,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testResetBroadcast() {
+	void testResetBroadcast() {
 		RestServiceV2 restServiceSpy = Mockito.spy(restService);
 
 		AntMediaApplicationAdapter adapter = Mockito.mock(AntMediaApplicationAdapter.class);
@@ -785,7 +763,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testShutDownStatus() {
+	void testShutDownStatus() {
 		RestServiceV2 restServiceSpy = Mockito.spy(restService);
 		AntMediaApplicationAdapter adaptor = Mockito.mock(AntMediaApplicationAdapter.class);
 
@@ -797,7 +775,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testExtractFQDN() {
+	void testExtractFQDN() {
 		String domain = CommonRestService.extractFQDN("http://example.com/path/to/page.html");
 		assertEquals("example.com", domain);
 
@@ -821,7 +799,7 @@ public class ConsoleRestV2UnitTest {
 	}
 	
 	@Test
-	public void testTriggerGC() {
+	void testTriggerGC() {
 		//just increase coverage and make sure that method is there.
 		//It's better to check if it calls System.gc. We may add it later with Powermockito. It's good enough at this stage 
 		RestServiceV2 restServiceSpy = Mockito.spy(restService);
@@ -830,7 +808,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testConfigureSSL() 
+	void testConfigureSSL()
 	{
 		RestServiceV2 restServiceSpy = Mockito.spy(restService);
 		AdminApplication adminApp = Mockito.mock(AdminApplication.class);
@@ -962,7 +940,7 @@ public class ConsoleRestV2UnitTest {
 	}
 
 	@Test
-	public void testAuthenticateMultiAppUser(){
+	void testAuthenticateMultiAppUser(){
 		
 		String password = "password";
 		
@@ -1003,7 +981,7 @@ public class ConsoleRestV2UnitTest {
 
 
 	@Test
-	public void testAppStatus(){
+	void testAppStatus(){
 		FileInputStream inputStream;
 		try{
 			inputStream = new FileInputStream("src/test/resources/sample_MP4_480.mp4");


### PR DESCRIPTION
https://github.com/ant-media/Ant-Media-Server/issues/7968

## What changed

- Inject `ConsoleDataStoreFactory`, `ServerSettings`, `IStatsCollector`, and the `web.handler` `AdminApplication` through Spring instead of resolving them lazily from the servlet context.
- Initialize the console datastore from the injected factory and mark direct datastore assignment as test-only.
- Inject `Optional<ILicenceService>` so contexts without a licence bean are tolerated.
- Simplify `IClusterNotifier` interface declarations.
- Update console REST unit coverage for the injection behavior.

## Why

The lazy context lookups exposed nullable return paths throughout `CommonRestService`, producing potential NPE findings in Sonar. These dependencies are Spring-managed and should have explicit injection contracts.

## Validation

- `mvn -q -Dtest=ConsoleRestV2UnitTest test`
- `git diff --check`
