### PR TITLE
Fix native library path in start script

### DIFF
--- a/src/main/server/start.sh
+++ b/src/main/server/start.sh
@@ -190,7 +190,7 @@ case "$OS" in
   ;;
   Linux*)
       ARCH=`uname -m`
-      LD_LIBRARY_PATH=$RED5_HOME/lib/native-linux-$ARCH
+      LD_LIBRARY_PATH=$RED5_HOME/lib/native-linux-$ARCH:$RED5_HOME/lib/native${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
       export LD_LIBRARY_PATH
       # Native path
       # First arch parameter is running start.sh directly and second lib/native parameter is installation for init.d scripts


### PR DESCRIPTION
https://github.com/ant-media/Ant-Media-Server/issues/7989

Fixes #7989

## Summary

- include the installed `lib/native` directory in `LD_LIBRARY_PATH`
- retain support for the extracted `lib/native-linux-$ARCH` layout
- preserve existing `LD_LIBRARY_PATH` entries

## Root cause

The installer moves `lib/native-$PLATFORM` to `lib/native`, and the systemd service uses that installed location. Direct startup through `start.sh` exported only `lib/native-linux-$ARCH`, so transitive native dependencies such as `libjnindi.so -> libndi.so.6` could not be resolved after installation.

## Validation

- `bash -n src/main/server/start.sh`
- `git diff --check`
