### PR TITLE
Parse sdp to understand whip audio/video preferences

### DIFF
--- a/src/main/java/io/antmedia/whip/SdpMediaInspector.java
+++ b/src/main/java/io/antmedia/whip/SdpMediaInspector.java
@@ -1,0 +1,135 @@
+package io.antmedia.whip;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Inspects the media sections of a WHIP offer to find out which tracks the publisher really sends.
+ *
+ * WHIP clients have no way to declare their tracks other than the SDP itself, so the flags cannot be
+ * trusted to come from the query parameters. If the server assumes audio while the publisher sends
+ * video only, the ingest waits for an audio clock that never advances and the video is not playable.
+ */
+public class SdpMediaInspector {
+
+	public static final String AUDIO = "audio";
+	public static final String VIDEO = "video";
+
+	private static final String MEDIA_PREFIX = "m=";
+	private static final String ATTRIBUTE_PREFIX = "a=";
+
+	private static final String SENDRECV = "sendrecv";
+	private static final String SENDONLY = "sendonly";
+	private static final String RECVONLY = "recvonly";
+	private static final String INACTIVE = "inactive";
+
+	protected static Logger logger = LoggerFactory.getLogger(SdpMediaInspector.class);
+
+	private SdpMediaInspector() {
+		//utility class
+	}
+
+	/**
+	 * Tells if the given media type is received from the publisher according to the SDP.
+	 *
+	 * It's true if there is at least one media section of this type that is not rejected(port 0) and
+	 * that sends media. Direction is read from the media section, it falls back to the session level
+	 * attribute and then to sendrecv which is the default in RFC 4566.
+	 *
+	 * @param sdp the offer, it may be null or blank because the caller does not validate it
+	 * @param mediaType {@link #AUDIO} or {@link #VIDEO}
+	 * @return true if the type is sent by the publisher, true as well if the SDP is not available to not change the flag
+	 */
+	public static boolean isMediaEnabled(String sdp, String mediaType) {
+		if (StringUtils.isBlank(sdp)) {
+			//nothing to inspect, leave the decision to the caller
+			return true;
+		}
+
+		String sessionDirection = null;
+		String currentDirection = null;
+		boolean inRequestedSection = false;
+		boolean sectionAccepted = false;
+		boolean beforeFirstSection = true;
+
+		for (String line : sdp.split("\\r?\\n")) {
+			line = line.trim();
+
+			if (line.startsWith(MEDIA_PREFIX)) {
+				//a new media section starts, so the previous one can be evaluated
+				if (inRequestedSection && sectionAccepted && isSending(direction(currentDirection, sessionDirection))) {
+					return true;
+				}
+
+				beforeFirstSection = false;
+				inRequestedSection = isMediaType(line, mediaType);
+				sectionAccepted = inRequestedSection && !isRejected(line);
+				currentDirection = null;
+			}
+			else if (line.startsWith(ATTRIBUTE_PREFIX)) {
+				String attribute = line.substring(ATTRIBUTE_PREFIX.length());
+				if (isDirection(attribute)) {
+					if (beforeFirstSection) {
+						sessionDirection = attribute;
+					}
+					else {
+						currentDirection = attribute;
+					}
+				}
+			}
+		}
+		//evaluate the last section because there is no media line after it
+		boolean isEnabled = inRequestedSection && sectionAccepted && isSending(direction(currentDirection, sessionDirection));
+		logger.info("Checking if media is enabled for {} in sdp, isEnabled: {}", mediaType, isEnabled);
+		return isEnabled;
+	}
+
+	/**
+	 * m=&lt;media&gt; &lt;port&gt; &lt;proto&gt; &lt;fmt&gt; ...
+	 */
+	private static boolean isMediaType(String mediaLine, String mediaType) {
+		String media = mediaLine.substring(MEDIA_PREFIX.length()).trim();
+		return media.equals(mediaType) || media.startsWith(mediaType + " ");
+	}
+
+	/**
+	 * Port 0 means the media section is rejected/disabled.
+	 */
+	private static boolean isRejected(String mediaLine) {
+		String[] fields = mediaLine.substring(MEDIA_PREFIX.length()).trim().split("\\s+");
+		if (fields.length < 2) {
+			//malformed media line, don't disable the track because of it
+			return false;
+		}
+
+		//port may be written as <port>/<number of ports>
+		String port = StringUtils.substringBefore(fields[1], "/");
+		try {
+			return Integer.parseInt(port) == 0;
+		}
+		catch (NumberFormatException e) {
+			return false;
+		}
+	}
+
+	private static boolean isDirection(String attribute) {
+		return SENDRECV.equals(attribute) || SENDONLY.equals(attribute)
+				|| RECVONLY.equals(attribute) || INACTIVE.equals(attribute);
+	}
+
+	private static String direction(String mediaDirection, String sessionDirection) {
+		if (mediaDirection != null) {
+			return mediaDirection;
+		}
+		return sessionDirection != null ? sessionDirection : SENDRECV;
+	}
+
+	/**
+	 * Server receives media only if the publisher sends it.
+	 */
+	private static boolean isSending(String direction) {
+		return SENDRECV.equals(direction) || SENDONLY.equals(direction);
+	}
+
+}

--- a/src/main/java/io/antmedia/whip/WhipEndpoint.java
+++ b/src/main/java/io/antmedia/whip/WhipEndpoint.java
@@ -91,8 +91,9 @@ public class WhipEndpoint extends RestServiceBase {
 		
 		publishParameters.setToken(token);
 		
-		publishParameters.setEnableVideo(enableVideo == null || enableVideo);
-		publishParameters.setEnableAudio(enableAudio == null || enableAudio);
+		//SDP is the ground truth for the tracks, query parameters can only disable them because most WHIP clients don't send any parameter
+		publishParameters.setEnableVideo((enableVideo == null || enableVideo) && SdpMediaInspector.isMediaEnabled(sdp, SdpMediaInspector.VIDEO));
+		publishParameters.setEnableAudio((enableAudio == null || enableAudio) && SdpMediaInspector.isMediaEnabled(sdp, SdpMediaInspector.AUDIO));
 		publishParameters.setSubscriberId(subscriberId);
 		publishParameters.setSubscriberCode(subscriberCode);
 		publishParameters.setStreamName(streamName);

--- a/src/test/java/io/antmedia/test/webrtc/SdpMediaInspectorTest.java
+++ b/src/test/java/io/antmedia/test/webrtc/SdpMediaInspectorTest.java
@@ -1,0 +1,137 @@
+package io.antmedia.test.webrtc;
+
+import static io.antmedia.whip.SdpMediaInspector.AUDIO;
+import static io.antmedia.whip.SdpMediaInspector.VIDEO;
+import static io.antmedia.whip.SdpMediaInspector.isMediaEnabled;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class SdpMediaInspectorTest {
+
+	private static final String SESSION = "v=0\n"
+			+ "o=- 4611731400430051336 2 IN IP4 127.0.0.1\n"
+			+ "s=-\n"
+			+ "t=0 0\n";
+
+	private static final String AUDIO_SECTION = "m=audio 9 UDP/TLS/RTP/SAVPF 111\n"
+			+ "c=IN IP4 0.0.0.0\n"
+			+ "a=mid:0\n"
+			+ "a=rtpmap:111 opus/48000/2\n";
+
+	private static final String VIDEO_SECTION = "m=video 9 UDP/TLS/RTP/SAVPF 96\n"
+			+ "c=IN IP4 0.0.0.0\n"
+			+ "a=mid:1\n"
+			+ "a=rtpmap:96 H264/90000\n";
+
+	@Test
+	public void testNoSdpDoesNotChangeTheFlags() {
+		//there is no information to inspect, so the query parameters stay as they are
+		assertTrue(isMediaEnabled(null, AUDIO));
+		assertTrue(isMediaEnabled("", VIDEO));
+		assertTrue(isMediaEnabled("   ", AUDIO));
+	}
+
+	@Test
+	public void testAudioAndVideo() {
+		//no direction attribute means sendrecv
+		String sdp = SESSION + AUDIO_SECTION + VIDEO_SECTION;
+
+		assertTrue(isMediaEnabled(sdp, AUDIO));
+		assertTrue(isMediaEnabled(sdp, VIDEO));
+	}
+
+	@Test
+	public void testVideoOnly() {
+		//this is the drone case, the offer has no audio section at all
+		String sdp = SESSION + VIDEO_SECTION;
+
+		assertFalse(isMediaEnabled(sdp, AUDIO));
+		assertTrue(isMediaEnabled(sdp, VIDEO));
+	}
+
+	@Test
+	public void testAudioOnly() {
+		String sdp = SESSION + AUDIO_SECTION;
+
+		assertTrue(isMediaEnabled(sdp, AUDIO));
+		assertFalse(isMediaEnabled(sdp, VIDEO));
+	}
+
+	@Test
+	public void testRejectedSectionIsNotEnabled() {
+		//port 0 means the section is rejected
+		String sdp = SESSION + "m=audio 0 UDP/TLS/RTP/SAVPF 111\na=mid:0\n" + VIDEO_SECTION;
+
+		assertFalse(isMediaEnabled(sdp, AUDIO));
+		assertTrue(isMediaEnabled(sdp, VIDEO));
+	}
+
+	@Test
+	public void testPortWithNumberOfPorts() {
+		String sdp = SESSION + "m=audio 9/2 UDP/TLS/RTP/SAVPF 111\na=mid:0\n";
+
+		assertTrue(isMediaEnabled(sdp, AUDIO));
+	}
+
+	@Test
+	public void testDirectionOfMediaSection() {
+		assertTrue(isMediaEnabled(SESSION + AUDIO_SECTION + "a=sendrecv\n", AUDIO));
+		assertTrue(isMediaEnabled(SESSION + AUDIO_SECTION + "a=sendonly\n", AUDIO));
+
+		//publisher does not send audio in these directions
+		assertFalse(isMediaEnabled(SESSION + AUDIO_SECTION + "a=recvonly\n", AUDIO));
+		assertFalse(isMediaEnabled(SESSION + AUDIO_SECTION + "a=inactive\n", AUDIO));
+	}
+
+	@Test
+	public void testDirectionDoesNotLeakToTheNextSection() {
+		//recvonly belongs to the audio section only
+		String sdp = SESSION + AUDIO_SECTION + "a=recvonly\n" + VIDEO_SECTION;
+
+		assertFalse(isMediaEnabled(sdp, AUDIO));
+		assertTrue(isMediaEnabled(sdp, VIDEO));
+	}
+
+	@Test
+	public void testSessionLevelDirection() {
+		//session level direction applies when the media section does not have one
+		String sdp = SESSION + "a=recvonly\n" + AUDIO_SECTION;
+		assertFalse(isMediaEnabled(sdp, AUDIO));
+
+		//media section overrides the session level direction
+		sdp = SESSION + "a=recvonly\n" + AUDIO_SECTION + "a=sendonly\n";
+		assertTrue(isMediaEnabled(sdp, AUDIO));
+	}
+
+	@Test
+	public void testOneSendingSectionIsEnough() {
+		//simulcast like offers may have more than one section of the same type
+		String sdp = SESSION + VIDEO_SECTION + "a=recvonly\n" + VIDEO_SECTION + "a=sendonly\n";
+
+		assertTrue(isMediaEnabled(sdp, VIDEO));
+	}
+
+	@Test
+	public void testCarriageReturnLineEndings() {
+		String sdp = (SESSION + VIDEO_SECTION).replace("\n", "\r\n");
+
+		assertFalse(isMediaEnabled(sdp, AUDIO));
+		assertTrue(isMediaEnabled(sdp, VIDEO));
+	}
+
+	@Test
+	public void testMalformedLinesDoNotDisableTheTrack() {
+		//don't break the publisher because of an unexpected media line
+		assertTrue(isMediaEnabled(SESSION + "m=audio\n", AUDIO));
+		assertTrue(isMediaEnabled(SESSION + "m=audio notaport UDP/TLS/RTP/SAVPF 111\n", AUDIO));
+	}
+
+	@Test
+	public void testMediaTypeIsNotMatchedPartially() {
+		//"m=videoo" is not a video section
+		assertFalse(isMediaEnabled(SESSION + "m=videoo 9 UDP/TLS/RTP/SAVPF 96\n", VIDEO));
+	}
+
+}

--- a/src/test/java/io/antmedia/test/webrtc/WhipEndpointTest.java
+++ b/src/test/java/io/antmedia/test/webrtc/WhipEndpointTest.java
@@ -136,7 +136,53 @@ public class WhipEndpointTest {
 	}
 	
 	@Test
-	public void testPrepareResponse() 
+	public void testTrackFlagsAreTakenFromSdp()
+	{
+		WhipEndpoint whipEndpoint = Mockito.spy(new WhipEndpoint());
+
+		AntMediaApplicationAdapter app = Mockito.mock(AntMediaApplicationAdapter.class);
+		Mockito.doReturn(app).when(whipEndpoint).getApplication();
+
+		CompletableFuture<Result> resultFuture = new CompletableFuture<>();
+		Mockito.when(app.startHttpSignaling(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(resultFuture);
+		resultFuture.complete(new Result(true));
+
+		String videoOnlySdp = "v=0\no=- 123 2 IN IP4 127.0.0.1\ns=-\nt=0 0\n"
+				+ "m=video 9 UDP/TLS/RTP/SAVPF 96\na=mid:0\na=rtpmap:96 H264/90000\n";
+
+		String audioVideoSdp = videoOnlySdp + "m=audio 9 UDP/TLS/RTP/SAVPF 111\na=mid:1\na=rtpmap:111 opus/48000/2\n";
+
+		ArgumentCaptor<PublishParameters> publishParamsCaptor = ArgumentCaptor.forClass(PublishParameters.class);
+
+		//audio is disabled because the offer has no audio section even though there is no query parameter
+		whipEndpoint.startWhipPublish(null, "stream123", null, null, null, null, null, null, null, null, null, videoOnlySdp);
+		Mockito.verify(app).startHttpSignaling(publishParamsCaptor.capture(), Mockito.any(), Mockito.anyString());
+		assertTrue(publishParamsCaptor.getValue().isEnableVideo());
+		assertFalse(publishParamsCaptor.getValue().isEnableAudio());
+
+		//both tracks are in the offer
+		publishParamsCaptor = ArgumentCaptor.forClass(PublishParameters.class);
+		whipEndpoint.startWhipPublish(null, "stream123", null, null, null, null, null, null, null, null, null, audioVideoSdp);
+		Mockito.verify(app, times(2)).startHttpSignaling(publishParamsCaptor.capture(), Mockito.any(), Mockito.anyString());
+		assertTrue(publishParamsCaptor.getValue().isEnableVideo());
+		assertTrue(publishParamsCaptor.getValue().isEnableAudio());
+
+		//query parameter can still disable a track that exists in the offer
+		publishParamsCaptor = ArgumentCaptor.forClass(PublishParameters.class);
+		whipEndpoint.startWhipPublish(null, "stream123", null, false, null, null, null, null, null, null, null, audioVideoSdp);
+		Mockito.verify(app, times(3)).startHttpSignaling(publishParamsCaptor.capture(), Mockito.any(), Mockito.anyString());
+		assertTrue(publishParamsCaptor.getValue().isEnableVideo());
+		assertFalse(publishParamsCaptor.getValue().isEnableAudio());
+
+		//query parameter cannot enable a track that is not in the offer
+		publishParamsCaptor = ArgumentCaptor.forClass(PublishParameters.class);
+		whipEndpoint.startWhipPublish(null, "stream123", null, true, null, null, null, null, null, null, null, videoOnlySdp);
+		Mockito.verify(app, times(4)).startHttpSignaling(publishParamsCaptor.capture(), Mockito.any(), Mockito.anyString());
+		assertFalse(publishParamsCaptor.getValue().isEnableAudio());
+	}
+
+	@Test
+	public void testPrepareResponse()
 	{
         WhipEndpoint whipEndpoint = Mockito.spy(new WhipEndpoint());
         


### PR DESCRIPTION
https://github.com/ant-media/Ant-Media-Server/issues/7979

Seems like some drones have no ability to send query parameters as well as audio. It fails on our end if there is no audio with no query parameters so this is to parse the SDP and understand if drone is sending audio/video at that moment.