### PR TITLE
fix: path traversal in FileUtil.unzip()

### DIFF
--- a/src/main/java/org/red5/server/util/FileUtil.java
+++ b/src/main/java/org/red5/server/util/FileUtil.java
@@ -322,9 +322,14 @@ public class FileUtil {
         try {
             zf = new ZipFile(compressedFileName);
             Enumeration<?> e = zf.entries();
+            String canonicalDest = tmpDir.getCanonicalPath() + File.separator;
             while (e.hasMoreElements()) {
                 ZipEntry ze = (ZipEntry) e.nextElement();
                 log.debug("Unzipping {}", ze.getName());
+                File destFile = new File(tmpDir, ze.getName());
+                if (!destFile.getCanonicalPath().startsWith(canonicalDest)) {
+                    throw new IOException("Zip entry outside target directory: " + ze.getName());
+                }
                 if (ze.isDirectory()) {
                     log.debug("is a directory");
                     File dir = new File(tmpDir + "/" + ze.getName());


### PR DESCRIPTION
Add canonical path check to reject zip entries that escape the target directory.

fix: #8026 
