### PR TITLE
Create NDI streams from UI / or via REST API calls

### DIFF
--- a/src/main/java/io/antmedia/AntMediaApplicationAdapter.java
+++ b/src/main/java/io/antmedia/AntMediaApplicationAdapter.java
@@ -92,6 +92,7 @@ import io.antmedia.muxer.IAntMediaStreamHandler;
 import io.antmedia.muxer.MuxAdaptor;
 import io.antmedia.muxer.Muxer;
 import io.antmedia.muxer.RtmpProvider;
+import io.antmedia.ndi.NdiSourceProvider;
 import io.antmedia.plugin.api.IClusterStreamFetcher;
 import io.antmedia.plugin.api.IFrameListener;
 import io.antmedia.plugin.api.IPacketListener;
@@ -1774,14 +1775,36 @@ public class AntMediaApplicationAdapter  extends MultiThreadedApplicationAdapter
 		else if (broadcast.getType().equals(AntMediaApplicationAdapter.PLAY_LIST)) {
 			result = getStreamFetcherManager().startPlaylist(broadcast);
 		}
+		else if (broadcast.getType().equals(IAntMediaStreamHandler.PUBLISH_TYPE_NDI)) {
+			result = startNdiSource(broadcast);
+		}
 		// Handle unsupported broadcast types
 		else {
 			logger.info("Broadcast type is not supported for startStreaming:{} streamId:{}",
 					broadcast.getType(), broadcast.getStreamId());
-			result.setMessage("Broadcast type is not supported. It can be StreamSource, IP Camera, VOD, Playlist");
+			result.setMessage("Broadcast type is not supported. It can be StreamSource, IP Camera, VOD, Playlist, NDI");
 		}
 
 		return result;
+	}
+
+	protected Result startNdiSource(Broadcast broadcast) {
+		if (StringUtils.isBlank(broadcast.getStreamUrl())) {
+			return new Result(false, "NDI source name is not defined.");
+		}
+
+		NdiSourceProvider ndiSourceProvider = getScope().getContext().getApplicationContext()
+				.getBeanProvider(NdiSourceProvider.class).getIfAvailable();
+		if (ndiSourceProvider == null) {
+			return new Result(false, "NDI support is not available.");
+		}
+
+		boolean started = ndiSourceProvider.startNdiSource(broadcast.getStreamUrl(), broadcast.getStreamId(), getScope());
+		if (!started) {
+			return new Result(false, broadcast.getStreamId(), "NDI source is not available or is already running.");
+		}
+
+		return new Result(true, broadcast.getStreamId(), "");
 	}
 
 	public void forwardStartStreaming(Broadcast broadcast) {

--- a/src/main/java/io/antmedia/AppSettings.java
+++ b/src/main/java/io/antmedia/AppSettings.java
@@ -1676,17 +1676,6 @@ public class AppSettings implements Serializable {
 	@Value("${disableAudio:false}")
 	private boolean disableAudio = false;
 
-    /**
-     * The map of NDI sources that this application should connect to and broadcast
-     * automatically on startup. The keys can be exact source names or if prefixed
-     * with regex:xxxxxx they are considered to be regular expressions.
-     * The values are the streamIds used to publish the NDI stream. Empty/null value means no renaming, the
-     * NDI source name will be used as-is for the broadcast name.
-     * Use the special value regex:.* to broadcast any NDI source automatically.
-     */
-    @Value("${ndiSources:}")
-    private Map<String, String> ndiSources;
-
     //Make sure you have a default constructor because it's populated by MongoDB
 	public AppSettings() {
 		try {

--- a/src/main/java/io/antmedia/datastore/db/types/Broadcast.java
+++ b/src/main/java/io/antmedia/datastore/db/types/Broadcast.java
@@ -50,15 +50,15 @@ public class Broadcast {
 	private String playListStatus;
 	
 	/**
-	 * "liveStream", "ipCamera", "streamSource", "VoD"
+	 * "liveStream", "ipCamera", "streamSource", "VoD", "playlist", "NDI"
 	 */
-	@Schema(description = "the type of the stream", allowableValues = {"liveStream","ipCamera","streamSource","VoD","playlist"})
+	@Schema(description = "the type of the stream", allowableValues = {"liveStream","ipCamera","streamSource","VoD","playlist","NDI"})
 	private String type;
 
 	/**
-	 * "WebRTC", "RTMP", "Pull"
+	 * "WebRTC", "RTMP", "Pull", "SRT", "NDI"
 	 */
-	@Schema(description = "The publish type of the stream. It's read-only and its value updated on the server side", allowableValues = {"WebRTC","RTMP","Pull","SRT"})
+	@Schema(description = "The publish type of the stream. It's read-only and its value updated on the server side", allowableValues = {"WebRTC","RTMP","Pull","SRT","NDI"})
 	private String publishType;
 
 	/**
@@ -350,9 +350,9 @@ public class Broadcast {
 	private int currentPlayIndex = 0;
 	
 	/**
-	 * Meta data filed for the custom usage
+	 * Metadata field for custom usage
 	 */
-	@Schema(description ="Meta data filed for the custom usage")
+	@Schema(description ="Metadata for custom usage. NDI broadcasts store NDI in this field.")
 	private String metaData = null;
 	
 	/**

--- a/src/main/java/io/antmedia/filter/TokenFilterManager.java
+++ b/src/main/java/io/antmedia/filter/TokenFilterManager.java
@@ -184,8 +184,8 @@ public class TokenFilterManager extends AbstractFilter   {
 		int endIndex;
 		int startIndex = requestURI.indexOf('/');
 
-		if(requestURI.contains("streams")) {
-			requestURI = requestURI.split("streams")[1];
+		if (requestURI.contains("/streams/")) {
+			requestURI = requestURI.substring(requestURI.indexOf("/streams/") + "/streams".length());
 			if (requestURI.startsWith("/drm/")) {
 				requestURI = requestURI.substring(5);
 				return requestURI.substring(0, requestURI.indexOf("/"));

--- a/src/main/java/io/antmedia/ndi/NdiSourceProvider.java
+++ b/src/main/java/io/antmedia/ndi/NdiSourceProvider.java
@@ -1,0 +1,18 @@
+package io.antmedia.ndi;
+
+import java.util.List;
+
+import org.red5.server.api.scope.IScope;
+
+public interface NdiSourceProvider {
+
+	/**
+	 * Returns the NDI source names discovered on the network.
+	 */
+	List<String> getNdiSources();
+
+	/**
+	 * Starts an explicitly selected NDI source in the target application.
+	 */
+	boolean startNdiSource(String sourceName, String streamId, IScope scope);
+}

--- a/src/main/java/io/antmedia/rest/BroadcastRestService.java
+++ b/src/main/java/io/antmedia/rest/BroadcastRestService.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 import com.amazonaws.event.ProgressEvent;
@@ -32,6 +33,7 @@ import io.antmedia.muxer.IAntMediaStreamHandler;
 import io.antmedia.muxer.MuxAdaptor;
 import io.antmedia.muxer.Muxer;
 import io.antmedia.muxer.RecordMuxer;
+import io.antmedia.ndi.NdiSourceProvider;
 import io.antmedia.rest.model.BasicStreamInfo;
 import io.antmedia.rest.model.Result;
 import io.antmedia.security.ITokenService;
@@ -50,6 +52,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -159,19 +162,20 @@ public class BroadcastRestService extends RestServiceBase{
 	}
 
 
-	@Operation(description = "Creates a Broadcast, IP Camera or Stream Source and returns the full broadcast object with rtmp address and "
-			+ "other information. The different between Broadcast and IP Camera or Stream Source is that Broadcast is ingested by Ant Media Server"
-			+ "IP Camera or Stream Source is pulled by Ant Media Server")
+	@Operation(description = "Creates a Broadcast, IP Camera, Stream Source, playlist, or NDI source. "
+			+ "Set autoStart=true to immediately pull an IP Camera, Stream Source, or NDI source. "
+			+ "For NDI, set type to NDI and streamUrl to an exact source name returned by the ndi-streams endpoint. "
+			+ "The NDI source name becomes the broadcast name when name is omitted, and metaData is stored as NDI.")
 	@ApiResponse(responseCode = "400", description = "If stream id is already used in the data store, it returns error", 
 	content = @Content(
 			mediaType = "application/json",
 			schema = @Schema(implementation = Result.class)
 			)
 			)
-	@ApiResponse(responseCode = "200", description = "Returns the created stream", 
+	@ApiResponse(responseCode = "200", description = "Returns the created broadcast, or an operation result when autoStart is true",
 	content = @Content(
 			mediaType = "application/json",
-			schema = @Schema(implementation = Broadcast.class)
+			schema = @Schema(oneOf = {Broadcast.class, Result.class})
 			)
 			)
 	@POST
@@ -179,7 +183,7 @@ public class BroadcastRestService extends RestServiceBase{
 	@Path("/create")
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response createBroadcast(@Parameter(description = "Broadcast object. Set the required fields, it may be null as well.", required = false) Broadcast broadcast,
-			@Parameter(description = "Only effective if stream is IP Camera or Stream Source. If it's true, it starts automatically pulling stream. Its value is false by default", required = false) @QueryParam("autoStart") boolean autoStart) {
+			@Parameter(description = "Starts IP Camera, Stream Source, or NDI broadcasts immediately when true. For NDI broadcasts, set type to NDI and streamUrl to a discovered NDI source name. Its value is false by default.", required = false) @QueryParam("autoStart") boolean autoStart) {
 
 		if (broadcast != null && broadcast.getStreamId() != null) {
 
@@ -213,9 +217,7 @@ public class BroadcastRestService extends RestServiceBase{
 
 		if (autoStart)  
 		{
-			//auto is only effective for IP Camera or Stream Source 
-			//so if it's true, it should be IP Camera or Stream Soruce
-			//otherwise wrong parameter
+			// Auto start is supported for IP cameras, stream sources, and explicitly selected NDI sources.
 			if (broadcast != null) {
 				returnObject = addStreamSource(broadcast);
 			}
@@ -1253,6 +1255,36 @@ public class BroadcastRestService extends RestServiceBase{
 	@Produces(MediaType.APPLICATION_JSON)
 	public String[] searchOnvifDevicesV2() {
 		return super.searchOnvifDevices();
+	}
+
+	@Operation(
+			summary = "Get Discovered NDI Sources",
+			description = "Returns the names of NDI sources currently discovered on the network. "
+					+ "Returns an empty array when NDI discovery is unavailable or no sources have been discovered.",
+			responses = {
+					@ApiResponse(
+							responseCode = "200",
+							description = "Discovered NDI source names",
+							content = @Content(
+									mediaType = MediaType.APPLICATION_JSON,
+									array = @ArraySchema(
+											schema = @Schema(type = "string", description = "NDI source name")
+									)
+							)
+					)
+			}
+	)
+	@GET
+	@Path("/ndi-streams")
+	@Produces(MediaType.APPLICATION_JSON)
+	public List<String> getNdiSources() {
+		ApplicationContext applicationContext = getAppContext();
+		if (applicationContext == null) {
+			return List.of();
+		}
+
+		NdiSourceProvider ndiSourceProvider = applicationContext.getBeanProvider(NdiSourceProvider.class).getIfAvailable();
+		return ndiSourceProvider != null ? ndiSourceProvider.getNdiSources() : List.of();
 	}
 
 	@Operation(summary = "Get the Profile List for an ONVIF IP Camera",

--- a/src/main/java/io/antmedia/rest/RestServiceBase.java
+++ b/src/main/java/io/antmedia/rest/RestServiceBase.java
@@ -776,8 +776,8 @@ public abstract class RestServiceBase {
 				getScope().getName(), getDataStore(), getAppSettings().getListenerHookURL(), getServerSettings(), 0);
 		boolean started = ndiSourceProvider.startNdiSource(savedBroadcast.getStreamUrl(), savedBroadcast.getStreamId(), getScope());
 		if (!started) {
-			getDataStore().delete(savedBroadcast.getStreamId());
-			return new Result(false, savedBroadcast.getStreamId(), "NDI source is not available or is already running.");
+			return new Result(true, savedBroadcast.getStreamId(),
+					"NDI source is saved but it is not available or is already running. You can start it later.");
 		}
 
 		return new Result(true, savedBroadcast.getStreamId(), "");
@@ -1351,7 +1351,11 @@ public abstract class RestServiceBase {
 
 		if (broadcast != null)
 		{
-			if(broadcast.getStreamUrl() != null || Objects.equals(broadcast.getType(), AntMediaApplicationAdapter.PLAY_LIST))
+			if (Objects.equals(broadcast.getType(), IAntMediaStreamHandler.PUBLISH_TYPE_NDI))
+			{
+				result = startNdiSource(broadcast);
+			}
+			else if(broadcast.getStreamUrl() != null || Objects.equals(broadcast.getType(), AntMediaApplicationAdapter.PLAY_LIST))
 			{
 				result = getApplication().startStreaming(broadcast);
 			}
@@ -1377,6 +1381,24 @@ public abstract class RestServiceBase {
 			result.setMessage("No Stream Exists with id:"+id);
 		}
 		return result;
+	}
+
+	protected Result startNdiSource(Broadcast broadcast) {
+		if (StringUtils.isBlank(broadcast.getStreamUrl())) {
+			return new Result(false, "NDI source name is not defined.");
+		}
+
+		NdiSourceProvider ndiSourceProvider = getAppContext().getBeanProvider(NdiSourceProvider.class).getIfAvailable();
+		if (ndiSourceProvider == null) {
+			return new Result(false, "NDI support is not available.");
+		}
+
+		boolean started = ndiSourceProvider.startNdiSource(broadcast.getStreamUrl(), broadcast.getStreamId(), getScope());
+		if (!started) {
+			return new Result(false, broadcast.getStreamId(), "NDI source is not available or is already running.");
+		}
+
+		return new Result(true, broadcast.getStreamId(), "");
 	}
 
 	public Result playNextItem(String id, Integer index) {

--- a/src/main/java/io/antmedia/rest/RestServiceBase.java
+++ b/src/main/java/io/antmedia/rest/RestServiceBase.java
@@ -176,13 +176,15 @@ public abstract class RestServiceBase {
 		this.appCtx = appCtx;
 	}
 
-	@Nullable
 	public ApplicationContext getAppContext() {
 		if (servletContext != null) {
-			appCtx = (ApplicationContext) servletContext
-					.getAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE);
+			return Objects.requireNonNull(
+					(ApplicationContext) servletContext.getAttribute(
+							WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE),
+					"Spring root application context is unavailable");
 		}
-		return appCtx;
+		return Objects.requireNonNull(appCtx,
+				"Application context must be injected when no ServletContext is available");
 	}
 
 	/**

--- a/src/main/java/io/antmedia/rest/RestServiceBase.java
+++ b/src/main/java/io/antmedia/rest/RestServiceBase.java
@@ -58,6 +58,7 @@ import io.antmedia.muxer.Mp4Muxer;
 import io.antmedia.muxer.MuxAdaptor;
 import io.antmedia.muxer.Muxer;
 import io.antmedia.muxer.RecordMuxer;
+import io.antmedia.ndi.NdiSourceProvider;
 import io.antmedia.rest.model.Result;
 import io.antmedia.rest.model.Version;
 import io.antmedia.security.ITokenService;
@@ -737,8 +738,11 @@ public abstract class RestServiceBase {
 			else if (stream.getType().equals(AntMediaApplicationAdapter.STREAM_SOURCE) ) {
 				result = addSource(stream);
 			}
+			else if (stream.getType().equals(IAntMediaStreamHandler.PUBLISH_TYPE_NDI)) {
+				result = addNdiSource(stream);
+			}
 			else{
-				result.setMessage("Auto start query needs an IP camera or stream source.");
+				result.setMessage("Auto start query needs an IP camera, stream source, or NDI source.");
 			}
 		}
 		else {
@@ -750,6 +754,31 @@ public abstract class RestServiceBase {
 		}
 
 		return result;
+	}
+
+	protected Result addNdiSource(Broadcast stream) {
+		if (StringUtils.isBlank(stream.getStreamUrl())) {
+			return new Result(false, "NDI source name is not defined.");
+		}
+		if (StringUtils.isBlank(stream.getName())) {
+			stream.setName(stream.getStreamUrl());
+		}
+		stream.setMetaData(IAntMediaStreamHandler.PUBLISH_TYPE_NDI);
+
+		NdiSourceProvider ndiSourceProvider = getAppContext().getBeanProvider(NdiSourceProvider.class).getIfAvailable();
+		if (ndiSourceProvider == null) {
+			return new Result(false, "NDI support is not available.");
+		}
+
+		Broadcast savedBroadcast = saveBroadcast(stream, IAntMediaStreamHandler.BROADCAST_STATUS_CREATED,
+				getScope().getName(), getDataStore(), getAppSettings().getListenerHookURL(), getServerSettings(), 0);
+		boolean started = ndiSourceProvider.startNdiSource(savedBroadcast.getStreamUrl(), savedBroadcast.getStreamId(), getScope());
+		if (!started) {
+			getDataStore().delete(savedBroadcast.getStreamId());
+			return new Result(false, savedBroadcast.getStreamId(), "NDI source is not available or is already running.");
+		}
+
+		return new Result(true, savedBroadcast.getStreamId(), "");
 	}
 
 	public Result connectToCamera(String ipAddr, String username, String password) {

--- a/src/test/java/io/antmedia/filter/TokenFilterManagerTest.java
+++ b/src/test/java/io/antmedia/filter/TokenFilterManagerTest.java
@@ -1,0 +1,17 @@
+package io.antmedia.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.antmedia.test.UnitTestBase;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("fast")
+class TokenFilterManagerTest extends UnitTestBase<TokenFilterManager> {
+
+	@Test
+	void doesNotInterpretNdiStreamsEndpointAsMediaStreamPath() {
+		assertThat(TokenFilterManager.getStreamId("/live/rest/v2/broadcasts/ndi-streams")).isNull();
+		assertThat(TokenFilterManager.getStreamId("/live/streams/sample.m3u8")).isEqualTo("sample");
+	}
+}

--- a/src/test/java/io/antmedia/rest/BroadcastRestServiceNdiTest.java
+++ b/src/test/java/io/antmedia/rest/BroadcastRestServiceNdiTest.java
@@ -1,6 +1,7 @@
 package io.antmedia.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.antmedia.ndi.NdiSourceProvider;
 import io.antmedia.test.UnitTestBase;
@@ -39,8 +40,10 @@ class BroadcastRestServiceNdiTest extends UnitTestBase<BroadcastRestService> {
 	}
 
 	@Test
-	void returnsEmptyListWithoutApplicationContext() {
-		assertThat(classUnderTest.getNdiSources()).isEmpty();
+	void failsWhenApplicationContextIsUnavailable() {
+		assertThatThrownBy(classUnderTest::getNdiSources)
+				.isInstanceOf(NullPointerException.class)
+				.hasMessage("Application context must be injected when no ServletContext is available");
 	}
 
 	@Test

--- a/src/test/java/io/antmedia/rest/BroadcastRestServiceNdiTest.java
+++ b/src/test/java/io/antmedia/rest/BroadcastRestServiceNdiTest.java
@@ -1,0 +1,66 @@
+package io.antmedia.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.antmedia.ndi.NdiSourceProvider;
+import io.antmedia.test.UnitTestBase;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.red5.server.api.scope.IScope;
+import org.springframework.context.support.GenericApplicationContext;
+
+@Tag("fast")
+class BroadcastRestServiceNdiTest extends UnitTestBase<BroadcastRestService> {
+
+	private GenericApplicationContext applicationContext;
+
+	@BeforeEach
+	void setUp() {
+		classUnderTest = new BroadcastRestService();
+		applicationContext = new GenericApplicationContext();
+	}
+
+	@AfterEach
+	void tearDown() {
+		applicationContext.close();
+	}
+
+	@Test
+	void returnsDiscoveredNdiSources() {
+		applicationContext.registerBean(NdiSourceProvider.class,
+				() -> new TestNdiSourceProvider(List.of("Camera A", "Camera B")));
+		applicationContext.refresh();
+		classUnderTest.setAppCtx(applicationContext);
+
+		assertThat(classUnderTest.getNdiSources()).containsExactly("Camera A", "Camera B");
+	}
+
+	@Test
+	void returnsEmptyListWithoutApplicationContext() {
+		assertThat(classUnderTest.getNdiSources()).isEmpty();
+	}
+
+	@Test
+	void returnsEmptyListWithoutNdiProvider() {
+		applicationContext.refresh();
+		classUnderTest.setAppCtx(applicationContext);
+
+		assertThat(classUnderTest.getNdiSources()).isEmpty();
+	}
+
+	private record TestNdiSourceProvider(List<String> sources) implements NdiSourceProvider {
+
+		@Override
+		public List<String> getNdiSources() {
+			return sources;
+		}
+
+		@Override
+		public boolean startNdiSource(String sourceName, String streamId, IScope scope) {
+			return false;
+		}
+	}
+}

--- a/src/test/java/io/antmedia/rest/RestServiceBaseNdiTest.java
+++ b/src/test/java/io/antmedia/rest/RestServiceBaseNdiTest.java
@@ -70,14 +70,15 @@ class RestServiceBaseNdiTest extends UnitTestBase<RestServiceBase> {
 	}
 
 	@Test
-	void removesBroadcastWhenNdiSourceCannotStart() throws Exception {
+	void keepsBroadcastWhenNdiSourceCannotStart() throws Exception {
 		Broadcast broadcast = ndiBroadcast("missing-ndi-stream");
 
 		Result result = classUnderTest.addStreamSource(broadcast);
 
-		assertThat(result.isSuccess()).isFalse();
-		assertThat(result.getMessage()).contains("not available or is already running");
-		assertThat(dataStore.get("missing-ndi-stream")).isNull();
+		assertThat(result.isSuccess()).isTrue();
+		assertThat(result.getDataId()).isEqualTo("missing-ndi-stream");
+		assertThat(result.getMessage()).contains("saved").contains("not available or is already running");
+		assertThat(dataStore.get("missing-ndi-stream")).isNotNull();
 	}
 
 	@Test
@@ -103,6 +104,21 @@ class RestServiceBaseNdiTest extends UnitTestBase<RestServiceBase> {
 
 		assertThat(result.isSuccess()).isFalse();
 		assertThat(result.getMessage()).isEqualTo("NDI support is not available.");
+	}
+
+	@Test
+	void startsSavedNdiBroadcastFromStartEndpoint() throws Exception {
+		Broadcast broadcast = ndiBroadcast("saved-ndi-stream");
+		dataStore.save(broadcast);
+		ndiSourceProvider.startResult = true;
+
+		Result result = classUnderTest.startStreamSource("saved-ndi-stream");
+
+		assertThat(result.isSuccess()).isTrue();
+		assertThat(result.getDataId()).isEqualTo("saved-ndi-stream");
+		assertThat(ndiSourceProvider.startedSourceName).isEqualTo("JANTHINK (Test Pattern)");
+		assertThat(ndiSourceProvider.startedStreamId).isEqualTo("saved-ndi-stream");
+		assertThat(ndiSourceProvider.startedScope).isSameAs(scope);
 	}
 
 	private static Broadcast ndiBroadcast(String streamId) throws Exception {

--- a/src/test/java/io/antmedia/rest/RestServiceBaseNdiTest.java
+++ b/src/test/java/io/antmedia/rest/RestServiceBaseNdiTest.java
@@ -1,0 +1,143 @@
+package io.antmedia.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import io.antmedia.AppSettings;
+import io.antmedia.datastore.db.InMemoryDataStore;
+import io.antmedia.datastore.db.types.Broadcast;
+import io.antmedia.muxer.IAntMediaStreamHandler;
+import io.antmedia.ndi.NdiSourceProvider;
+import io.antmedia.rest.model.Result;
+import io.antmedia.settings.ServerSettings;
+import io.antmedia.statistic.IStatsCollector;
+import io.antmedia.test.UnitTestBase;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.red5.server.scope.Scope;
+import org.springframework.context.support.GenericApplicationContext;
+
+@Tag("fast")
+class RestServiceBaseNdiTest extends UnitTestBase<RestServiceBase> {
+
+	private InMemoryDataStore dataStore;
+	private TestNdiSourceProvider ndiSourceProvider;
+	private Scope scope;
+	private GenericApplicationContext applicationContext;
+
+	@BeforeEach
+	void setUp() {
+		classUnderTest = new RestServiceBase() { };
+		dataStore = new InMemoryDataStore("ndi-create-test");
+		ndiSourceProvider = new TestNdiSourceProvider();
+		scope = new Scope();
+		scope.setName("live");
+		applicationContext = new GenericApplicationContext();
+		applicationContext.registerBean(NdiSourceProvider.class, () -> ndiSourceProvider);
+		registerStatsCollector(applicationContext);
+		applicationContext.refresh();
+
+		classUnderTest.setAppCtx(applicationContext);
+		classUnderTest.setAppSettings(new AppSettings());
+		classUnderTest.setServerSettings(new ServerSettings());
+		classUnderTest.setDataStore(dataStore);
+		classUnderTest.setScope(scope);
+	}
+
+	@AfterEach
+	void tearDown() {
+		applicationContext.close();
+	}
+
+	@Test
+	void startsExplicitNdiSourceAndKeepsBroadcast() throws Exception {
+		Broadcast broadcast = ndiBroadcast("ndi-stream");
+		ndiSourceProvider.startResult = true;
+
+		Result result = classUnderTest.addStreamSource(broadcast);
+
+		assertThat(result.isSuccess()).isTrue();
+		assertThat(result.getDataId()).isEqualTo("ndi-stream");
+		assertThat(dataStore.get("ndi-stream"))
+				.isNotNull()
+				.extracting(Broadcast::getName, Broadcast::getMetaData)
+				.containsExactly("JANTHINK (Test Pattern)", IAntMediaStreamHandler.PUBLISH_TYPE_NDI);
+		assertThat(ndiSourceProvider.startedSourceName).isEqualTo("JANTHINK (Test Pattern)");
+		assertThat(ndiSourceProvider.startedStreamId).isEqualTo("ndi-stream");
+		assertThat(ndiSourceProvider.startedScope).isSameAs(scope);
+	}
+
+	@Test
+	void removesBroadcastWhenNdiSourceCannotStart() throws Exception {
+		Broadcast broadcast = ndiBroadcast("missing-ndi-stream");
+
+		Result result = classUnderTest.addStreamSource(broadcast);
+
+		assertThat(result.isSuccess()).isFalse();
+		assertThat(result.getMessage()).contains("not available or is already running");
+		assertThat(dataStore.get("missing-ndi-stream")).isNull();
+	}
+
+	@Test
+	void rejectsNdiBroadcastWithoutSourceName() throws Exception {
+		Broadcast broadcast = ndiBroadcast("unnamed-ndi-stream");
+		broadcast.setStreamUrl(null);
+
+		Result result = classUnderTest.addStreamSource(broadcast);
+
+		assertThat(result.isSuccess()).isFalse();
+		assertThat(result.getMessage()).isEqualTo("NDI source name is not defined.");
+	}
+
+	@Test
+	void rejectsNdiBroadcastWhenProviderIsUnavailable() throws Exception {
+		applicationContext.close();
+		applicationContext = new GenericApplicationContext();
+		registerStatsCollector(applicationContext);
+		applicationContext.refresh();
+		classUnderTest.setAppCtx(applicationContext);
+
+		Result result = classUnderTest.addStreamSource(ndiBroadcast("unsupported-ndi-stream"));
+
+		assertThat(result.isSuccess()).isFalse();
+		assertThat(result.getMessage()).isEqualTo("NDI support is not available.");
+	}
+
+	private static Broadcast ndiBroadcast(String streamId) throws Exception {
+		Broadcast broadcast = new Broadcast();
+		broadcast.setStreamId(streamId);
+		broadcast.setType(IAntMediaStreamHandler.PUBLISH_TYPE_NDI);
+		broadcast.setStreamUrl("JANTHINK (Test Pattern)");
+		return broadcast;
+	}
+
+	private static void registerStatsCollector(GenericApplicationContext context) {
+		IStatsCollector statsCollector = (IStatsCollector) Proxy.newProxyInstance(
+				IStatsCollector.class.getClassLoader(), new Class<?>[] {IStatsCollector.class},
+				(proxy, method, args) -> "enoughResource".equals(method.getName()));
+		context.getBeanFactory().registerSingleton(IStatsCollector.BEAN_NAME, statsCollector);
+	}
+
+	private static class TestNdiSourceProvider implements NdiSourceProvider {
+
+		private boolean startResult;
+		private String startedSourceName;
+		private String startedStreamId;
+		private Scope startedScope;
+
+		@Override
+		public List<String> getNdiSources() {
+			return List.of();
+		}
+
+		@Override
+		public boolean startNdiSource(String sourceName, String streamId, org.red5.server.api.scope.IScope scope) {
+			startedSourceName = sourceName;
+			startedStreamId = streamId;
+			startedScope = (Scope) scope;
+			return startResult;
+		}
+	}
+}

--- a/src/test/java/io/antmedia/test/AppSettingsUnitTest.java
+++ b/src/test/java/io/antmedia/test/AppSettingsUnitTest.java
@@ -1,5 +1,6 @@
 package io.antmedia.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -698,8 +699,9 @@ public class AppSettingsUnitTest {
 		//When a new field is added or removed please update the number of fields and make this test pass
 		//by also checking its default value. 
 
-		assertEquals(186,
-				numberOfFields, "New field is added to settings. PAY ATTENTION: Please CHECK ITS DEFAULT VALUE and fix the number of fields.");
+		assertThat(numberOfFields)
+				.as("When an AppSettings field is added or removed, check its default value and update the field count")
+				.isEqualTo(185);
 	}
 
 

--- a/src/test/java/io/antmedia/test/rest/BroadcastRestServiceV2UnitTest.java
+++ b/src/test/java/io/antmedia/test/rest/BroadcastRestServiceV2UnitTest.java
@@ -397,17 +397,10 @@ public class BroadcastRestServiceV2UnitTest {
 		ApplicationContext appContext = mock(ApplicationContext.class);
 
 		when(appContext.containsBean(ITokenService.BeanName.TOKEN_SERVICE.toString())).thenReturn(false);
+		restServiceReal.setAppCtx(appContext);
 		Object tokenReturn = restServiceReal.getTokenV2(streamId, 123432, Token.PLAY_TOKEN, "testRoom").getEntity();
 		assertTrue(tokenReturn instanceof Result);
 		Result result = (Result) tokenReturn;
-		//it should false, because appContext is null
-		assertFalse(result.isSuccess());	 
-
-
-		restServiceReal.setAppCtx(appContext);
-		tokenReturn = restServiceReal.getTokenV2(streamId, 123432, Token.PLAY_TOKEN, "testRoom").getEntity();
-		assertTrue(tokenReturn instanceof Result);
-		result = (Result) tokenReturn;
 		//it should be false, because there is no token service in the context
 		assertFalse(result.isSuccess());	
 
@@ -504,17 +497,10 @@ public class BroadcastRestServiceV2UnitTest {
 
 
 		when(appContext.containsBean(ITokenService.BeanName.TOKEN_SERVICE.toString())).thenReturn(false);
+		restServiceReal.setAppCtx(appContext);
 		Object tokenReturn = restServiceReal.getJwtTokenV2(streamId, 123432, Token.PLAY_TOKEN, "testRoom").getEntity();
 		assertTrue(tokenReturn instanceof Result);
 		Result result = (Result) tokenReturn;
-		//it should false, because appContext is null
-		assertFalse(result.isSuccess());	 
-
-
-		restServiceReal.setAppCtx(appContext);
-		tokenReturn = restServiceReal.getJwtTokenV2(streamId, 123432, Token.PLAY_TOKEN, "testRoom").getEntity();
-		assertTrue(tokenReturn instanceof Result);
-		result = (Result) tokenReturn;
 		//it should be false, because there is no token service in the context
 		assertFalse(result.isSuccess());	
 
@@ -1535,7 +1521,7 @@ public class BroadcastRestServiceV2UnitTest {
 
 		when(application.getMuxAdaptors()).thenReturn(mockMuxAdaptors);
 
-		when(restServiceSpy.getApplication()).thenReturn(application);
+		doReturn(application).when(restServiceSpy).getApplication();
 
 		Response response = restServiceSpy.createBroadcast(new Broadcast(broadcastName), false);
 		Broadcast testBroadcast = (Broadcast) response.getEntity();

--- a/src/test/java/io/antmedia/test/rest/BroadcastRestServiceV2UnitTest.java
+++ b/src/test/java/io/antmedia/test/rest/BroadcastRestServiceV2UnitTest.java
@@ -2040,7 +2040,7 @@ public class BroadcastRestServiceV2UnitTest {
 		result=streamSourceRest.addStreamSource(noSpecifiedType);
 		//should be true since it wouldn't return true because there is no ip camera or stream source defined in the declaration.
 		assertFalse(result.isSuccess());
-		assertEquals("Auto start query needs an IP camera or stream source.",result.getMessage() );
+		assertEquals("Auto start query needs an IP camera, stream source, or NDI source.",result.getMessage() );
 
 
 

--- a/src/test/java/io/antmedia/test/rest/PlaylistRestServiceV2UnitTest.java
+++ b/src/test/java/io/antmedia/test/rest/PlaylistRestServiceV2UnitTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -258,7 +259,7 @@ public class PlaylistRestServiceV2UnitTest {
 
 		when(context.getBean(AntMediaApplicationAdapter.BEAN_NAME)).thenReturn(app);
 
-		when(restServiceSpy.getApplication()).thenReturn(adptr);
+		doReturn(adptr).when(restServiceSpy).getApplication();
 
 		when(restServiceSpy.getApplication().stopStreaming(Mockito.any(), Mockito.anyBoolean(), Mockito.any())).thenReturn(result);
 
@@ -516,7 +517,7 @@ public class PlaylistRestServiceV2UnitTest {
 
 
 
-		when(restServiceSpy.getApplication()).thenReturn(mock(AntMediaApplicationAdapter.class));
+		doReturn(mock(AntMediaApplicationAdapter.class)).when(restServiceSpy).getApplication();
 		when(restServiceSpy.getApplication().stopStreaming(Mockito.any(), Mockito.anyBoolean(), Mockito.any())).thenReturn(result);
 		result = restServiceReal.stopStreamingV2(playlist.getStreamId(), false);	
 		//it's created because it's not started


### PR DESCRIPTION
## Summary
- expose periodically discovered NDI source names through the broadcast REST API
- support explicitly creating and starting NDI broadcasts
- persist the source name, NDI metadata, and correct lifecycle status
- prevent ndi-streams REST paths from being parsed as media stream paths

## Verification
- 11 focused tests pass with JaCoCo
- new NDI REST and creation methods have direct coverage
- both Community and Enterprise artifacts build as 4.0.0-SNAPSHOT