### PR TITLE
Add multi-track DVB-TTML subtitles to HLS

### DIFF
--- a/src/main/java/io/antmedia/filter/TokenFilterManager.java
+++ b/src/main/java/io/antmedia/filter/TokenFilterManager.java
@@ -28,8 +28,8 @@ public class TokenFilterManager extends AbstractFilter   {
 	public static final String NOT_INITIALIZED= "Not initialized";
 	protected static Logger logger = LoggerFactory.getLogger(TokenFilterManager.class);
 	public static final String TOKEN_HEADER_FOR_NODE_COMMUNICATION = "ClusterAuthorization";
-	private static final Pattern WEBVTT_SUBTITLE_FILE_PATTERN = Pattern.compile(
-			"([^/]+)_subtitles_[0-9]+(?:_[0-9]+)?\\.(?:m3u8|vtt)$");
+	private static final Pattern WEBVTT_SUBTITLE_FILE_SUFFIX_PATTERN = Pattern.compile(
+			"_subtitles_\\d+(?:_\\d+)?\\.(?:m3u8|vtt)$");
 
 
 	@Override
@@ -211,9 +211,12 @@ public class TokenFilterManager extends AbstractFilter   {
 			return requestURI.substring(startIndex+1, endIndex);
 		}
 
-		Matcher webVttSubtitleMatcher = WEBVTT_SUBTITLE_FILE_PATTERN.matcher(requestURI);
+		Matcher webVttSubtitleMatcher = WEBVTT_SUBTITLE_FILE_SUFFIX_PATTERN.matcher(requestURI);
 		if (webVttSubtitleMatcher.find()) {
-			return webVttSubtitleMatcher.group(1);
+			int streamIdStart = requestURI.lastIndexOf('/', webVttSubtitleMatcher.start()) + 1;
+			if (streamIdStart < webVttSubtitleMatcher.start()) {
+				return requestURI.substring(streamIdStart, webVttSubtitleMatcher.start());
+			}
 		}
 
 

--- a/src/main/java/io/antmedia/filter/TokenFilterManager.java
+++ b/src/main/java/io/antmedia/filter/TokenFilterManager.java
@@ -28,6 +28,8 @@ public class TokenFilterManager extends AbstractFilter   {
 	public static final String NOT_INITIALIZED= "Not initialized";
 	protected static Logger logger = LoggerFactory.getLogger(TokenFilterManager.class);
 	public static final String TOKEN_HEADER_FOR_NODE_COMMUNICATION = "ClusterAuthorization";
+	private static final Pattern WEBVTT_SUBTITLE_FILE_PATTERN = Pattern.compile(
+			"([^/]+)_subtitles_[0-9]+(?:_[0-9]+)?\\.(?:m3u8|vtt)$");
 
 
 	@Override
@@ -207,6 +209,11 @@ public class TokenFilterManager extends AbstractFilter   {
 			startIndex = requestURI.indexOf("/");
 			endIndex = requestURI.lastIndexOf("/");
 			return requestURI.substring(startIndex+1, endIndex);
+		}
+
+		Matcher webVttSubtitleMatcher = WEBVTT_SUBTITLE_FILE_PATTERN.matcher(requestURI);
+		if (webVttSubtitleMatcher.find()) {
+			return webVttSubtitleMatcher.group(1);
 		}
 
 

--- a/src/main/java/io/antmedia/muxer/HLSMuxer.java
+++ b/src/main/java/io/antmedia/muxer/HLSMuxer.java
@@ -503,7 +503,6 @@ public class HLSMuxer extends Muxer  {
 		return new MasterPlaylistParser().writePlaylistAsString(playlist.build());
 	}
 
-	@VisibleForTesting
 	static String addWebVttToMasterPlaylistContent(Collection<WebVttTrack> tracks, String baseName,
 			String masterPlaylistContent) throws IOException {
 		MasterPlaylistParser parser = new MasterPlaylistParser();
@@ -540,7 +539,6 @@ public class HLSMuxer extends Muxer  {
 		return renditions;
 	}
 
-	@VisibleForTesting
 	static String getPrimaryVariantUri(String masterPlaylistContent) throws IOException {
 		List<Variant> variants = new MasterPlaylistParser().readPlaylist(masterPlaylistContent).variants();
 		if (variants.isEmpty()) {

--- a/src/main/java/io/antmedia/muxer/HLSMuxer.java
+++ b/src/main/java/io/antmedia/muxer/HLSMuxer.java
@@ -12,13 +12,19 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonObject;
@@ -42,6 +48,11 @@ import org.slf4j.LoggerFactory;
 
 import io.antmedia.storage.StorageClient;
 import io.vertx.core.Vertx;
+import io.lindstrom.m3u8.model.AlternativeRendition;
+import io.lindstrom.m3u8.model.MasterPlaylist;
+import io.lindstrom.m3u8.model.MediaType;
+import io.lindstrom.m3u8.model.Variant;
+import io.lindstrom.m3u8.parser.MasterPlaylistParser;
 
 public class HLSMuxer extends Muxer  {
 
@@ -55,8 +66,7 @@ public class HLSMuxer extends Muxer  {
 	public static final String HLS_SEGMENT_TYPE_MPEGTS = "mpegts";
 	public static final String HLS_SEGMENT_TYPE_FMP4 = "fmp4";
 
-	public static final String HLS_FILES_REGEX_MATCHER = "(\\d{9}\\.(ts|fmp4)|\\.m3u8)$";
-	
+	public static final String HLS_FILES_REGEX_MATCHER = "(\\d{9}\\.(ts|fmp4)|\\d+\\.vtt|\\.m3u8)$";
 	private static final String VARIANT_AUDIO_GROUP = "audio";
 
 
@@ -101,9 +111,12 @@ public class HLSMuxer extends Muxer  {
 	private AVPacket tmpPacketForSEI;
 
 	private String segmentFileNameSuffix;
-	
 	private boolean variantStreamMappingEnabled;
-	
+	private final Map<Integer, WebVttTrack> webVttTracks = new ConcurrentHashMap<>();
+	private final Map<Integer, WebVttHlsPlaylist> webVttPlaylists = new ConcurrentHashMap<>();
+	private File webVttMasterPlaylist;
+	private long lastMediaPlaylistModified = -1;
+	private long lastMediaPlaylistSize = -1;
 
 
 	public HLSMuxer(Vertx vertx, StorageClient storageClient, String s3StreamsFolderPath, int uploadExtensionsToS3, String httpEndpoint, boolean addDateTimeToResourceName) {
@@ -224,6 +237,11 @@ public class HLSMuxer extends Muxer  {
 			
 			options.put("start_number", ""+startIndex);
 
+			if (!webVttTracks.isEmpty()) {
+				webVttMasterPlaylist = new File(file.getParentFile(), initialResourceNameWithoutExtension + "_master.m3u8");
+				webVttTracks.values().forEach(this::createWebVttPlaylist);
+			}
+
 
 			tmpPacketForSEI = avcodec.av_packet_alloc();
 			isInitialized = true;
@@ -264,6 +282,14 @@ public class HLSMuxer extends Muxer  {
 	}
 
 	@Override
+	protected boolean checkToDropPacket(AVPacket pkt, int codecType) {
+		if (webVttTracks.containsKey(pkt.stream_index()) && codecType == AVMEDIA_TYPE_DATA) {
+			return true;
+		}
+		return super.checkToDropPacket(pkt, codecType);
+	}
+
+	@Override
 	public synchronized void writePacket(AVPacket pkt, AVRational inputTimebase, AVRational outputTimebase, int codecType)
 	{
 
@@ -298,6 +324,9 @@ public class HLSMuxer extends Muxer  {
 		} 
 		else {
 			super.writePacket(pkt, inputTimebase, outputTimebase, codecType);
+		}
+		if (codecType == AVMEDIA_TYPE_VIDEO && !webVttTracks.isEmpty()) {
+			syncWebVttPlaylists(false);
 		}
 
 	}
@@ -384,7 +413,102 @@ public class HLSMuxer extends Muxer  {
 	public boolean writeHeader() {
 		configureVariantStreamMappingIfRequired();
 		createID3StreamIfRequired();
-		return super.writeHeader();
+		boolean result = super.writeHeader();
+		if (result && !webVttTracks.isEmpty()) {
+			writeWebVttMasterPlaylist();
+		}
+		return result;
+	}
+
+	public void setWebVttTracks(Collection<WebVttTrack> tracks) {
+		webVttTracks.clear();
+		tracks.forEach(this::addWebVttTrack);
+	}
+
+	public void addWebVttTrack(WebVttTrack track) {
+		webVttTracks.put(track.inputStreamIndex(), track);
+		if (file != null) {
+			createWebVttPlaylist(track);
+		}
+	}
+
+	public synchronized void writeWebVttCue(int inputStreamIndex, WebVttCue cue) {
+		WebVttHlsPlaylist playlist = webVttPlaylists.get(inputStreamIndex);
+		if (playlist == null || !isRunning.get()) {
+			return;
+		}
+		try {
+			playlist.addCue(cue);
+		}
+		catch (IOException e) {
+			logger.error("Cannot write WebVTT cue for stream:{} inputIndex:{}", streamId, inputStreamIndex, e);
+		}
+	}
+
+	private void writeWebVttMasterPlaylist() {
+		String content = createWebVttMasterPlaylistContent(webVttTracks.values(), initialResourceNameWithoutExtension,
+				file.getName());
+		File temporaryFile = new File(webVttMasterPlaylist.getParentFile(), webVttMasterPlaylist.getName() + ".tmp");
+		try {
+			Files.writeString(temporaryFile.toPath(), content, StandardCharsets.UTF_8);
+			Files.move(temporaryFile.toPath(), webVttMasterPlaylist.toPath(), StandardCopyOption.REPLACE_EXISTING,
+					StandardCopyOption.ATOMIC_MOVE);
+			logger.info("WebVTT master playlist is written for stream:{} path:{}", streamId, webVttMasterPlaylist);
+		}
+		catch (IOException e) {
+			logger.error("Cannot write WebVTT master playlist for stream:{}", streamId, e);
+		}
+	}
+
+	@VisibleForTesting
+	static String createWebVttMasterPlaylistContent(Collection<WebVttTrack> tracks, String baseName,
+			String mediaPlaylistName) {
+		MasterPlaylist.Builder playlist = MasterPlaylist.builder().version(3);
+		int trackNumber = 0;
+		for (WebVttTrack track : tracks.stream().sorted(Comparator.comparingInt(WebVttTrack::inputStreamIndex)).toList()) {
+			playlist.addAlternativeRenditions(AlternativeRendition.builder()
+					.type(MediaType.SUBTITLES)
+					.groupId("subs")
+					.name(sanitizePlaylistAttribute(track.name()))
+					.language(sanitizePlaylistAttribute(track.language()))
+					.defaultRendition(trackNumber++ == 0)
+					.autoSelect(true)
+					.uri(WebVttHlsPlaylist.playlistName(track, baseName))
+					.build());
+		}
+		playlist.addVariants(Variant.builder().bandwidth(1_000_000).subtitles("subs").uri(mediaPlaylistName).build());
+		return new MasterPlaylistParser().writePlaylistAsString(playlist.build());
+	}
+
+	private static String sanitizePlaylistAttribute(String value) {
+		return value.replace('"', '\'').replace('\r', ' ').replace('\n', ' ').replace('\t', ' ');
+	}
+
+	private void createWebVttPlaylist(WebVttTrack track) {
+		webVttPlaylists.computeIfAbsent(track.inputStreamIndex(), ignored ->
+				new WebVttHlsPlaylist(track, file.getParentFile(), initialResourceNameWithoutExtension));
+	}
+
+	private void syncWebVttPlaylists(boolean force) {
+		if (file == null || !file.isFile()) {
+			return;
+		}
+		long modified = file.lastModified();
+		long size = file.length();
+		if (!force && modified == lastMediaPlaylistModified && size == lastMediaPlaylistSize) {
+			return;
+		}
+		try {
+			String mediaPlaylistContent = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+			for (WebVttHlsPlaylist playlist : webVttPlaylists.values()) {
+				playlist.update(mediaPlaylistContent);
+			}
+			lastMediaPlaylistModified = modified;
+			lastMediaPlaylistSize = size;
+		}
+		catch (IOException | RuntimeException e) {
+			logger.warn("Cannot synchronize WebVTT playlists for stream:{}", streamId, e);
+		}
 	}
 	
 	public void configureVariantStreamMappingIfRequired() {
@@ -507,6 +631,7 @@ public class HLSMuxer extends Muxer  {
 			return;
 
 		super.writeTrailer();
+		syncWebVttPlaylists(true);
 
 		//We provide a solution to have full mp4 recording even for stream are interrupted.
 		//It works in this way:
@@ -569,10 +694,9 @@ public class HLSMuxer extends Muxer  {
 	
 	public String getHLSFilesRegularExpression(int indexOfSuffix) {
 		String segmentFileWithoutSuffix = segmentFilename.substring(segmentFilename.lastIndexOf("/")+1, indexOfSuffix);
-		String hlsFileExtensions = TS_EXTENSION + "|" + FMP4_EXTENSION;
+		String hlsFileExtensions = TS_EXTENSION + "|" + FMP4_EXTENSION + "|vtt|m3u8";
 		if (variantStreamMappingEnabled) {
 			segmentFileWithoutSuffix = segmentFileWithoutSuffix.replace("%v", ".*");
-			hlsFileExtensions += "|m3u8";
 		}
 		return segmentFileWithoutSuffix + ".*\\.(?:" + hlsFileExtensions + ")$";
 	}

--- a/src/main/java/io/antmedia/muxer/HLSMuxer.java
+++ b/src/main/java/io/antmedia/muxer/HLSMuxer.java
@@ -68,6 +68,7 @@ public class HLSMuxer extends Muxer  {
 
 	public static final String HLS_FILES_REGEX_MATCHER = "(\\d{9}\\.(ts|fmp4)|\\d+\\.vtt|\\.m3u8)$";
 	private static final String VARIANT_AUDIO_GROUP = "audio";
+	private static final String SUBTITLE_GROUP = "subs";
 
 
 	protected static Logger logger = LoggerFactory.getLogger(HLSMuxer.class);
@@ -115,6 +116,8 @@ public class HLSMuxer extends Muxer  {
 	private final Map<Integer, WebVttTrack> webVttTracks = new ConcurrentHashMap<>();
 	private final Map<Integer, WebVttHlsPlaylist> webVttPlaylists = new ConcurrentHashMap<>();
 	private File webVttMasterPlaylist;
+	private File webVttMediaPlaylist;
+	private WebVttMasterPlaylistSynchronizer webVttMasterPlaylistSynchronizer;
 	private long lastMediaPlaylistModified = -1;
 	private long lastMediaPlaylistSize = -1;
 
@@ -239,6 +242,7 @@ public class HLSMuxer extends Muxer  {
 
 			if (!webVttTracks.isEmpty()) {
 				webVttMasterPlaylist = new File(file.getParentFile(), initialResourceNameWithoutExtension + "_master.m3u8");
+				webVttMediaPlaylist = file;
 				webVttTracks.values().forEach(this::createWebVttPlaylist);
 			}
 
@@ -326,6 +330,7 @@ public class HLSMuxer extends Muxer  {
 			super.writePacket(pkt, inputTimebase, outputTimebase, codecType);
 		}
 		if (codecType == AVMEDIA_TYPE_VIDEO && !webVttTracks.isEmpty()) {
+			syncWebVttMasterPlaylist(false);
 			syncWebVttPlaylists(false);
 		}
 
@@ -415,7 +420,16 @@ public class HLSMuxer extends Muxer  {
 		createID3StreamIfRequired();
 		boolean result = super.writeHeader();
 		if (result && !webVttTracks.isEmpty()) {
-			writeWebVttMasterPlaylist();
+			if (variantStreamMappingEnabled) {
+				webVttMasterPlaylist = file;
+				webVttMediaPlaylist = null;
+				webVttMasterPlaylistSynchronizer = new WebVttMasterPlaylistSynchronizer(file,
+						webVttTracks.values(), initialResourceNameWithoutExtension);
+				syncWebVttMasterPlaylist(false);
+			}
+			else {
+				writeWebVttMasterPlaylist();
+			}
 		}
 		return result;
 	}
@@ -448,15 +462,34 @@ public class HLSMuxer extends Muxer  {
 	private void writeWebVttMasterPlaylist() {
 		String content = createWebVttMasterPlaylistContent(webVttTracks.values(), initialResourceNameWithoutExtension,
 				file.getName());
-		File temporaryFile = new File(webVttMasterPlaylist.getParentFile(), webVttMasterPlaylist.getName() + ".tmp");
 		try {
+			File temporaryFile = new File(webVttMasterPlaylist.getParentFile(), webVttMasterPlaylist.getName() + ".tmp");
 			Files.writeString(temporaryFile.toPath(), content, StandardCharsets.UTF_8);
 			Files.move(temporaryFile.toPath(), webVttMasterPlaylist.toPath(), StandardCopyOption.REPLACE_EXISTING,
 					StandardCopyOption.ATOMIC_MOVE);
 			logger.info("WebVTT master playlist is written for stream:{} path:{}", streamId, webVttMasterPlaylist);
 		}
-		catch (IOException e) {
+		catch (IOException | RuntimeException e) {
 			logger.error("Cannot write WebVTT master playlist for stream:{}", streamId, e);
+		}
+	}
+
+	private void syncWebVttMasterPlaylist(boolean force) {
+		if (webVttMasterPlaylistSynchronizer == null) {
+			return;
+		}
+		try {
+			Optional<String> mediaPlaylistName = webVttMasterPlaylistSynchronizer.synchronize(force);
+			if (mediaPlaylistName.isPresent()) {
+				webVttMediaPlaylist = new File(file.getParentFile(), mediaPlaylistName.get());
+				File obsoleteStandaloneMaster = new File(file.getParentFile(),
+						initialResourceNameWithoutExtension + "_master.m3u8");
+				Files.deleteIfExists(obsoleteStandaloneMaster.toPath());
+			}
+		}
+		catch (IOException | RuntimeException e) {
+			logger.warn("Cannot synchronize WebVTT master playlist for stream:{} path:{}",
+					streamId, webVttMasterPlaylist, e);
 		}
 	}
 
@@ -464,11 +497,39 @@ public class HLSMuxer extends Muxer  {
 	static String createWebVttMasterPlaylistContent(Collection<WebVttTrack> tracks, String baseName,
 			String mediaPlaylistName) {
 		MasterPlaylist.Builder playlist = MasterPlaylist.builder().version(3);
+		playlist.alternativeRenditions(createSubtitleRenditions(tracks, baseName));
+		playlist.addVariants(Variant.builder().bandwidth(1_000_000).subtitles(SUBTITLE_GROUP)
+				.uri(mediaPlaylistName).build());
+		return new MasterPlaylistParser().writePlaylistAsString(playlist.build());
+	}
+
+	@VisibleForTesting
+	static String addWebVttToMasterPlaylistContent(Collection<WebVttTrack> tracks, String baseName,
+			String masterPlaylistContent) throws IOException {
+		MasterPlaylistParser parser = new MasterPlaylistParser();
+		MasterPlaylist source = parser.readPlaylist(masterPlaylistContent);
+		List<AlternativeRendition> renditions = new ArrayList<>(source.alternativeRenditions());
+		renditions.removeIf(rendition -> rendition.type() == MediaType.SUBTITLES
+				&& SUBTITLE_GROUP.equals(rendition.groupId()));
+		renditions.addAll(createSubtitleRenditions(tracks, baseName));
+		List<Variant> variants = source.variants().stream()
+				.map(variant -> Variant.builder().from(variant).subtitles(SUBTITLE_GROUP).build())
+				.toList();
+		MasterPlaylist merged = MasterPlaylist.builder().from(source)
+				.alternativeRenditions(renditions)
+				.variants(variants)
+				.build();
+		return parser.writePlaylistAsString(merged);
+	}
+
+	private static List<AlternativeRendition> createSubtitleRenditions(Collection<WebVttTrack> tracks,
+			String baseName) {
+		List<AlternativeRendition> renditions = new ArrayList<>();
 		int trackNumber = 0;
 		for (WebVttTrack track : tracks.stream().sorted(Comparator.comparingInt(WebVttTrack::inputStreamIndex)).toList()) {
-			playlist.addAlternativeRenditions(AlternativeRendition.builder()
+			renditions.add(AlternativeRendition.builder()
 					.type(MediaType.SUBTITLES)
-					.groupId("subs")
+					.groupId(SUBTITLE_GROUP)
 					.name(sanitizePlaylistAttribute(track.name()))
 					.language(sanitizePlaylistAttribute(track.language()))
 					.defaultRendition(trackNumber++ == 0)
@@ -476,8 +537,16 @@ public class HLSMuxer extends Muxer  {
 					.uri(WebVttHlsPlaylist.playlistName(track, baseName))
 					.build());
 		}
-		playlist.addVariants(Variant.builder().bandwidth(1_000_000).subtitles("subs").uri(mediaPlaylistName).build());
-		return new MasterPlaylistParser().writePlaylistAsString(playlist.build());
+		return renditions;
+	}
+
+	@VisibleForTesting
+	static String getPrimaryVariantUri(String masterPlaylistContent) throws IOException {
+		List<Variant> variants = new MasterPlaylistParser().readPlaylist(masterPlaylistContent).variants();
+		if (variants.isEmpty()) {
+			throw new IllegalArgumentException("HLS master playlist does not contain a media variant");
+		}
+		return variants.get(0).uri();
 	}
 
 	private static String sanitizePlaylistAttribute(String value) {
@@ -490,24 +559,25 @@ public class HLSMuxer extends Muxer  {
 	}
 
 	private void syncWebVttPlaylists(boolean force) {
-		if (file == null || !file.isFile()) {
+		if (webVttMediaPlaylist == null || !webVttMediaPlaylist.isFile()) {
 			return;
 		}
-		long modified = file.lastModified();
-		long size = file.length();
+		long modified = webVttMediaPlaylist.lastModified();
+		long size = webVttMediaPlaylist.length();
 		if (!force && modified == lastMediaPlaylistModified && size == lastMediaPlaylistSize) {
 			return;
 		}
+		lastMediaPlaylistModified = modified;
+		lastMediaPlaylistSize = size;
 		try {
-			String mediaPlaylistContent = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+			String mediaPlaylistContent = Files.readString(webVttMediaPlaylist.toPath(), StandardCharsets.UTF_8);
 			for (WebVttHlsPlaylist playlist : webVttPlaylists.values()) {
 				playlist.update(mediaPlaylistContent);
 			}
-			lastMediaPlaylistModified = modified;
-			lastMediaPlaylistSize = size;
 		}
 		catch (IOException | RuntimeException e) {
-			logger.warn("Cannot synchronize WebVTT playlists for stream:{}", streamId, e);
+			logger.warn("Cannot synchronize WebVTT playlists for stream:{} mediaPlaylist:{}",
+					streamId, webVttMediaPlaylist, e);
 		}
 	}
 	
@@ -631,6 +701,7 @@ public class HLSMuxer extends Muxer  {
 			return;
 
 		super.writeTrailer();
+		syncWebVttMasterPlaylist(true);
 		syncWebVttPlaylists(true);
 
 		//We provide a solution to have full mp4 recording even for stream are interrupted.

--- a/src/main/java/io/antmedia/muxer/HLSMuxer.java
+++ b/src/main/java/io/antmedia/muxer/HLSMuxer.java
@@ -20,9 +20,12 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -524,12 +527,26 @@ public class HLSMuxer extends Muxer  {
 	private static List<AlternativeRendition> createSubtitleRenditions(Collection<WebVttTrack> tracks,
 			String baseName) {
 		List<AlternativeRendition> renditions = new ArrayList<>();
+		List<WebVttTrack> sortedTracks = tracks.stream()
+				.sorted(Comparator.comparingInt(WebVttTrack::inputStreamIndex)).toList();
+		List<String> preferredNames = sortedTracks.stream().map(HLSMuxer::subtitleName).toList();
+		Set<String> reservedNames = new HashSet<>(preferredNames);
+		Set<String> usedNames = new HashSet<>();
 		int trackNumber = 0;
-		for (WebVttTrack track : tracks.stream().sorted(Comparator.comparingInt(WebVttTrack::inputStreamIndex)).toList()) {
+		for (WebVttTrack track : sortedTracks) {
+			String preferredName = preferredNames.get(trackNumber);
+			String name = preferredName;
+			int suffix = 2;
+			// HLS rendition names must be unique within the group. Reserve metadata
+			// labels so an auto-generated suffix cannot take another track's name.
+			while (usedNames.contains(name) || (!name.equals(preferredName) && reservedNames.contains(name))) {
+				name = preferredName + " (" + suffix++ + ")";
+			}
+			usedNames.add(name);
 			renditions.add(AlternativeRendition.builder()
 					.type(MediaType.SUBTITLES)
 					.groupId(SUBTITLE_GROUP)
-					.name(sanitizePlaylistAttribute(track.name()))
+					.name(name)
 					.language(sanitizePlaylistAttribute(track.language()))
 					.defaultRendition(trackNumber++ == 0)
 					.autoSelect(true)
@@ -537,6 +554,21 @@ public class HLSMuxer extends Muxer  {
 					.build());
 		}
 		return renditions;
+	}
+
+	private static String subtitleName(WebVttTrack track) {
+		String name = sanitizePlaylistAttribute(track.name()).strip();
+		if (!name.isEmpty() && !"DVB-TTML".equalsIgnoreCase(name) && !"Subtitles".equalsIgnoreCase(name)) {
+			return name;
+		}
+		String language = track.language().strip();
+		if (!"und".equalsIgnoreCase(language)) {
+			String languageName = Locale.forLanguageTag(language).getDisplayLanguage(Locale.ENGLISH);
+			if (!languageName.isBlank()) {
+				return sanitizePlaylistAttribute(languageName);
+			}
+		}
+		return "Subtitles";
 	}
 
 	static String getPrimaryVariantUri(String masterPlaylistContent) throws IOException {

--- a/src/main/java/io/antmedia/muxer/HLSMuxer.java
+++ b/src/main/java/io/antmedia/muxer/HLSMuxer.java
@@ -558,7 +558,7 @@ public class HLSMuxer extends Muxer  {
 
 	private static String subtitleName(WebVttTrack track) {
 		String name = sanitizePlaylistAttribute(track.name()).strip();
-		if (!name.isEmpty() && !"DVB-TTML".equalsIgnoreCase(name) && !"Subtitles".equalsIgnoreCase(name)) {
+		if (!"DVB-TTML".equalsIgnoreCase(name) && !"Subtitles".equalsIgnoreCase(name)) {
 			return name;
 		}
 		String language = track.language().strip();

--- a/src/main/java/io/antmedia/muxer/MuxAdaptor.java
+++ b/src/main/java/io/antmedia/muxer/MuxAdaptor.java
@@ -118,6 +118,7 @@ public class MuxAdaptor implements IRecordingListener, IEndpointStatusListener {
 
 	private int videoStreamIndex;
 	private int dataStreamIndex;
+	private final Map<Integer, WebVttTrack> webVttTracks = new ConcurrentHashMap<>();
 
 
 	protected boolean previewOverwrite = false;
@@ -537,6 +538,7 @@ public class MuxAdaptor implements IRecordingListener, IEndpointStatusListener {
 
 	public HLSMuxer addHLSMuxer() {
 		HLSMuxer hlsMuxer = new HLSMuxer(vertx, storageClient, getAppSettings().getS3StreamsFolderPath(), getAppSettings().getUploadExtensionsToS3(), getAppSettings().getHlsHttpEndpoint(), getAppSettings().isAddDateTimeToHlsFileName());
+		hlsMuxer.setWebVttTracks(webVttTracks.values());
 		hlsMuxer.setHlsParameters(hlsListSize, hlsTime, hlsPlayListType, getAppSettings().getHlsflags(), 
 									getAppSettings().getHlsEncryptionKeyInfoFile(), getAppSettings().getHlsSegmentType());
 		hlsMuxer.setDeleteFileOnExit(deleteHLSFilesOnExit);
@@ -1846,6 +1848,37 @@ public class MuxAdaptor implements IRecordingListener, IEndpointStatusListener {
 				if (!(muxer instanceof WebMMuxer))
 				{
 					muxer.writePacket(pkt, stream);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Registers a source stream that an ingest implementation will convert to WebVTT.
+	 * Registration must happen before {@link #init(IScope, String, boolean)}.
+	 */
+	public void registerWebVttTrack(int inputStreamIndex, String language, String name) {
+		WebVttTrack track = new WebVttTrack(inputStreamIndex, language, name);
+		webVttTracks.put(inputStreamIndex, track);
+		synchronized (muxerList) {
+			for (Muxer muxer : muxerList) {
+				if (muxer instanceof HLSMuxer hlsMuxer) {
+					hlsMuxer.addWebVttTrack(track);
+				}
+			}
+		}
+		logger.debug("WebVTT track registered for stream:{} inputIndex:{} language:{} name:{}",
+				streamId, inputStreamIndex, track.language(), track.name());
+	}
+
+	public void writeWebVttCue(int inputStreamIndex, WebVttCue cue) {
+		if (!webVttTracks.containsKey(inputStreamIndex)) {
+			return;
+		}
+		synchronized (muxerList) {
+			for (Muxer muxer : muxerList) {
+				if (muxer instanceof HLSMuxer hlsMuxer) {
+					hlsMuxer.writeWebVttCue(inputStreamIndex, cue);
 				}
 			}
 		}

--- a/src/main/java/io/antmedia/muxer/Muxer.java
+++ b/src/main/java/io/antmedia/muxer/Muxer.java
@@ -1233,7 +1233,7 @@ public abstract class Muxer {
 	 * @param codecType
 	 * @return true to drop the packet, false to not drop packet
 	 */
-	public boolean checkToDropPacket(AVPacket pkt, int codecType) {
+	protected boolean checkToDropPacket(AVPacket pkt, int codecType) {
 		if (!firstKeyFrameReceived && codecType == AVMEDIA_TYPE_VIDEO) 
 		{
 			if(firstPacketDtsMs == -1) {

--- a/src/main/java/io/antmedia/muxer/Muxer.java
+++ b/src/main/java/io/antmedia/muxer/Muxer.java
@@ -1341,14 +1341,10 @@ public abstract class Muxer {
 			startTimeInSeconds = currentTimeInSeconds;
 		}
 
-		if (codecType == AVMEDIA_TYPE_AUDIO) {
-			writeAudioPacket(pkt, inputTimebase, outputTimebase, context, originalTiming.dts());
-		}
-		else if (codecType == AVMEDIA_TYPE_VIDEO) {
-			writeVideoPacket(pkt, inputTimebase, outputTimebase, context);
-		}
-		else {
-			writeOtherPacket(pkt, inputTimebase, outputTimebase, context);
+		switch (codecType) {
+			case AVMEDIA_TYPE_AUDIO -> writeAudioPacket(pkt, inputTimebase, outputTimebase, context, originalTiming.dts());
+			case AVMEDIA_TYPE_VIDEO -> writeVideoPacket(pkt, inputTimebase, outputTimebase, context);
+			default -> writeOtherPacket(pkt, inputTimebase, outputTimebase, context);
 		}
 
 		restorePacketTiming(pkt, originalTiming);

--- a/src/main/java/io/antmedia/muxer/Muxer.java
+++ b/src/main/java/io/antmedia/muxer/Muxer.java
@@ -371,6 +371,7 @@ public abstract class Muxer {
 		return addStream(codec, codecContext, streamIndex, Optional.empty());
 	}
 
+	@SuppressWarnings("java:S1172") // Kept for the polymorphic API; subclasses such as DASHMuxer use the codec.
 	public synchronized boolean addStream(AVCodec codec, AVCodecContext codecContext, int streamIndex,
 			Optional<String> language) {
 
@@ -507,49 +508,10 @@ public abstract class Muxer {
 	}
 
 	protected synchronized void clearResource() {
-		if (tmpPacket != null) {
-			av_packet_free(tmpPacket);
-			tmpPacket = null;
-		}
+		clearPackets();
+		clearBitstreamFilters();
 
-		if (videoPkt != null) {
-			av_packet_free(videoPkt);
-			videoPkt = null;
-		}
-
-		if (audioPkt != null) {
-			av_packet_free(audioPkt);
-			audioPkt = null;
-		}
-
-		for (AVBSFContext videoBsfFilterContext: bsfFilterContextList) {
-			av_bsf_free(videoBsfFilterContext);
-		}
-		bsfFilterContextList.clear();
-		
-		Set<AVBSFContext> releasedAudioBsfFilterContextSet = new HashSet<>();
-		for (Set<AVBSFContext> audioBsfFilterContextSet : bsfAudioFilterContextMap.values()) {
-			for (AVBSFContext audioBsfFilterContext : audioBsfFilterContextSet) {
-				if (releasedAudioBsfFilterContextSet.add(audioBsfFilterContext)) {
-					av_bsf_free(audioBsfFilterContext);
-				}
-			}
-		}
-		for (AVBSFContext audioBsfFilterContext : bsfAudioFilterContextList) {
-			if (releasedAudioBsfFilterContextSet.add(audioBsfFilterContext)) {
-				av_bsf_free(audioBsfFilterContext);
-			}
-		}
-		bsfAudioFilterContextMap.clear();
-		bsfAudioFilterContextList.clear();
-		firstAudioDtsMap.clear();
-
-		/* close output */
-		if (outputFormatContext != null &&
-				(outputFormatContext.oformat().flags() & AVFMT_NOFILE) == 0 
-						&& outputFormatContext.pb() != null
-						&& (outputFormatContext.flags() & AVFormatContext.AVFMT_FLAG_CUSTOM_IO) == 0)
-		{
+		if (shouldCloseOutputContext()) {
 			avio_closep(outputFormatContext.pb());
 		}
 
@@ -583,6 +545,54 @@ public abstract class Muxer {
 		//      test callers (build a Map-backed copy on demand).
 		// See: crash investigation 2026-04-30 (av_dict_free → av_freep SEGV after
 		// rw_timeout-bounded openIO race with writeTrailer teardown).
+	}
+
+	private void clearPackets() {
+		if (tmpPacket != null) {
+			av_packet_free(tmpPacket);
+			tmpPacket = null;
+		}
+
+		if (videoPkt != null) {
+			av_packet_free(videoPkt);
+			videoPkt = null;
+		}
+
+		if (audioPkt != null) {
+			av_packet_free(audioPkt);
+			audioPkt = null;
+		}
+	}
+
+	private void clearBitstreamFilters() {
+		for (AVBSFContext videoBsfFilterContext: bsfFilterContextList) {
+			av_bsf_free(videoBsfFilterContext);
+		}
+		bsfFilterContextList.clear();
+		
+		Set<AVBSFContext> releasedAudioBsfFilterContextSet = new HashSet<>();
+		for (Set<AVBSFContext> audioBsfFilterContextSet : bsfAudioFilterContextMap.values()) {
+			for (AVBSFContext audioBsfFilterContext : audioBsfFilterContextSet) {
+				if (releasedAudioBsfFilterContextSet.add(audioBsfFilterContext)) {
+					av_bsf_free(audioBsfFilterContext);
+				}
+			}
+		}
+		for (AVBSFContext audioBsfFilterContext : bsfAudioFilterContextList) {
+			if (releasedAudioBsfFilterContextSet.add(audioBsfFilterContext)) {
+				av_bsf_free(audioBsfFilterContext);
+			}
+		}
+		bsfAudioFilterContextMap.clear();
+		bsfAudioFilterContextList.clear();
+		firstAudioDtsMap.clear();
+	}
+
+	private boolean shouldCloseOutputContext() {
+		return outputFormatContext != null &&
+				(outputFormatContext.oformat().flags() & AVFMT_NOFILE) == 0 
+						&& outputFormatContext.pb() != null
+						&& (outputFormatContext.flags() & AVFormatContext.AVFMT_FLAG_CUSTOM_IO) == 0;
 	}
 
 	/**
@@ -987,84 +997,100 @@ public abstract class Muxer {
 			logger.warn("It is already running and cannot add new stream while it's running for stream:{} and output:{}", streamId, getOutputURL());
 			return false;
 		}
-		boolean result = false;
 		AVFormatContext outputContext = getOutputFormatContext();
-		if (outputContext != null 
-				&& isCodecSupported(codecParameters.codec_id()) &&
-				(codecParameters.codec_type() == AVMEDIA_TYPE_AUDIO || codecParameters.codec_type() == AVMEDIA_TYPE_VIDEO)
-				)
-		{
+		if (codecParameters.codec_type() == AVMEDIA_TYPE_DATA) {
+			return addDataStream(outputContext, codecParameters, timebase, streamIndex);
+		}
+		if (!isSupportedMediaStream(outputContext, codecParameters)) {
+			logger.warn("Stream is not added for muxing to {} for stream:{}", getFileName(), streamId);
+			return false;
+		}
+		return addMediaStream(outputContext, codecParameters, timebase, streamIndex, language);
+	}
 
-			
+	private boolean isSupportedMediaStream(AVFormatContext outputContext, AVCodecParameters codecParameters) {
+		int codecType = codecParameters.codec_type();
+		return outputContext != null && isCodecSupported(codecParameters.codec_id())
+				&& (codecType == AVMEDIA_TYPE_AUDIO || codecType == AVMEDIA_TYPE_VIDEO);
+	}
+
+	private boolean addMediaStream(AVFormatContext outputContext, AVCodecParameters codecParameters,
+			AVRational timebase, int streamIndex, Optional<String> language) {
+		AVStream outStream = avNewStream(outputContext);
+		registeredStreamIndexList.add(streamIndex);
+
+		boolean video = codecParameters.codec_type() == AVMEDIA_TYPE_VIDEO;
+		FilteredStreamParameters filtered = video
+				? applyVideoBitstreamFilters(codecParameters, timebase)
+				: applyAudioBitstreamFilters(codecParameters, timebase, streamIndex);
+		codecParameters = filtered.codecParameters();
+		timebase = filtered.timebase();
+
+		if (video) {
+			videoWidth = codecParameters.width();
+			videoHeight = codecParameters.height();
+			videoCodecId = codecParameters.codec_id();
+		}
+
+		avcodec_parameters_copy(outStream.codecpar(), codecParameters);
+		setStreamLanguage(outStream, language);
+		logger.info("Adding timebase to the input time base map index:{} value: {}/{} for stream:{} type:{}",
+				outStream.index(), timebase.num(), timebase.den(), streamId, video ? "video" : "audio");
+		inputTimeBaseMap.put(streamIndex, timebase);
+		inputOutputStreamIndexMap.put(streamIndex, outStream.index());
+		mapAudioBitstreamFiltersToOutputStream(codecParameters, streamIndex, outStream.index());
+		outStream.codecpar().codec_tag(0);
+		return true;
+	}
+
+	private FilteredStreamParameters applyVideoBitstreamFilters(AVCodecParameters codecParameters,
+			AVRational timebase) {
+		for (String bsfVideoName: bsfVideoNames) {
+			AVBSFContext filter = initVideoBitstreamFilter(bsfVideoName, codecParameters, timebase);
+			if (filter != null) {
+				codecParameters = filter.par_out();
+				timebase = filter.time_base_out();
+			}
+		}
+		return new FilteredStreamParameters(codecParameters, timebase);
+	}
+
+	private FilteredStreamParameters applyAudioBitstreamFilters(AVCodecParameters codecParameters,
+			AVRational timebase, int streamIndex) {
+		for (String bsfAudioName : bsfAudioNames) {
+			AVBSFContext filter = initAudioBitstreamFilter(bsfAudioName, codecParameters, timebase, streamIndex);
+			if (filter != null) {
+				codecParameters = filter.par_out();
+				timebase = filter.time_base_out();
+			}
+		}
+		return new FilteredStreamParameters(codecParameters, timebase);
+	}
+
+	private void mapAudioBitstreamFiltersToOutputStream(AVCodecParameters codecParameters, int inputStreamIndex,
+			int outputStreamIndex) {
+		Set<AVBSFContext> filters = bsfAudioFilterContextMap.get(inputStreamIndex);
+		if (codecParameters.codec_type() == AVMEDIA_TYPE_AUDIO && outputStreamIndex != inputStreamIndex
+				&& filters != null) {
+			bsfAudioFilterContextMap.put(outputStreamIndex, filters);
+		}
+	}
+
+	private boolean addDataStream(AVFormatContext outputContext, AVCodecParameters codecParameters,
+			AVRational timebase, int streamIndex) {
+		if(codecParameters.codec_id() == AV_CODEC_ID_TIMED_ID3) {
 			AVStream outStream = avNewStream(outputContext);
-			//if it's not running add to the list
 			registeredStreamIndexList.add(streamIndex);
-
-			String codecType;
-			if (codecParameters.codec_type() == AVMEDIA_TYPE_VIDEO)
-			{
-				codecType = "video";
-				for (String bsfVideoName: bsfVideoNames) {
-					AVBSFContext videoBitstreamFilter = initVideoBitstreamFilter(bsfVideoName, codecParameters, timebase);
-					if (videoBitstreamFilter != null)
-					{
-						codecParameters = videoBitstreamFilter.par_out();
-						timebase = videoBitstreamFilter.time_base_out();
-					}
-				}
-				videoWidth = codecParameters.width();
-				videoHeight = codecParameters.height();
-				videoCodecId = codecParameters.codec_id();
-			}
-			else 
-			{
-				codecType = "audio";
-				for (String bsfAudioName : bsfAudioNames) {
-					AVBSFContext audioBitstreamFilter = initAudioBitstreamFilter(bsfAudioName, codecParameters,
-							timebase, streamIndex);
-					if (audioBitstreamFilter != null) {
-						codecParameters = audioBitstreamFilter.par_out();
-						timebase = audioBitstreamFilter.time_base_out();
-					}
-				}
-			}
-
 			avcodec_parameters_copy(outStream.codecpar(), codecParameters);
-			setStreamLanguage(outStream, language);
-			logger.info("Adding timebase to the input time base map index:{} value: {}/{} for stream:{} type:{}", 
-					outStream.index(), timebase.num(), timebase.den(), streamId, codecType);
+			logger.info("Adding ID3 stream timebase to the input time base map index:{} value: {}/{} for stream:{}",
+					outStream.index(), timebase.num(), timebase.den(), streamId);
 			inputTimeBaseMap.put(streamIndex, timebase);
 			inputOutputStreamIndexMap.put(streamIndex, outStream.index());
-			Set<AVBSFContext> audioFilterContexts = bsfAudioFilterContextMap.get(streamIndex);
-			if (codecParameters.codec_type() == AVMEDIA_TYPE_AUDIO && outStream.index() != streamIndex && audioFilterContexts != null) {
-				bsfAudioFilterContextMap.put(outStream.index(), audioFilterContexts);
-			}
-
-			outStream.codecpar().codec_tag(0);
-			result = true;
-
 		}
-		else if (codecParameters.codec_type() == AVMEDIA_TYPE_DATA) 
-		{
-			if(codecParameters.codec_id() == AV_CODEC_ID_TIMED_ID3) 
-			{
-				AVStream outStream = avNewStream(outputContext);
-				registeredStreamIndexList.add(streamIndex);
-
-				avcodec_parameters_copy(outStream.codecpar(), codecParameters);
-				logger.info("Adding ID3 stream timebase to the input time base map index:{} value: {}/{} for stream:{}",
-						outStream.index(), timebase.num(), timebase.den(), streamId);
-				inputTimeBaseMap.put(streamIndex, timebase);
-				inputOutputStreamIndexMap.put(streamIndex, outStream.index());
-			}
-			//if it's data, do not add and return true
-			result = true;
-		}
-		else {
-			logger.warn("Stream is not added for muxing to {} for stream:{}", getFileName(), streamId);
-		}
-		return result;
+		return true;
 	}
+
+	private record FilteredStreamParameters(AVCodecParameters codecParameters, AVRational timebase) { }
 
 	protected Optional<String> normalizeLanguage(Optional<String> language) {
 		return language.map(String::trim).filter(value -> !value.isEmpty());
@@ -1303,11 +1329,7 @@ public abstract class Muxer {
 	public synchronized void writePacket(AVPacket pkt, AVRational inputTimebase, AVRational outputTimebase, int codecType)
 	{
 		AVFormatContext context = getOutputFormatContext();
-
-		long pts = pkt.pts();
-		long dts = pkt.dts();
-		long duration = pkt.duration();
-		long pos = pkt.pos();
+		PacketTiming originalTiming = new PacketTiming(pkt.pts(), pkt.dts(), pkt.duration(), pkt.pos());
 
 		pkt.duration(av_rescale_q(pkt.duration(), inputTimebase, outputTimebase));
 		pkt.pos(-1);
@@ -1319,94 +1341,94 @@ public abstract class Muxer {
 			startTimeInSeconds = currentTimeInSeconds;
 		}
 
-		if (codecType == AVMEDIA_TYPE_AUDIO)
-		{
-			int audioStreamIndex = pkt.stream_index();
-			long firstAudioDtsForStream;
-			//removing firstAudioDTS is required when recording/muxing has started on the fly
-			if(firstPacketDtsMs == -1) {
-				firstAudioDtsForStream = pkt.dts();
-				firstPacketDtsMs  = av_rescale_q(pkt.dts(), inputTimebase, MuxAdaptor.TIME_BASE_FOR_MS);
-				firstAudioDtsMap.put(audioStreamIndex, firstAudioDtsForStream);
-				firstAudioDts = firstAudioDtsForStream;
-				logger.debug("The first incoming packet is audio and its packet dts:{}ms streamId:{} ", firstPacketDtsMs, streamId);
-			}
-			else {
-				Long storedFirstAudioDts = firstAudioDtsMap.get(audioStreamIndex);
-				if (storedFirstAudioDts == null) {
-					firstAudioDtsForStream = av_rescale_q(firstPacketDtsMs, MuxAdaptor.TIME_BASE_FOR_MS, inputTimebase);
-					logger.debug("First packetDtsMs:{}ms is already received calculated the firstAudioDts:{} and incoming packet dts:{} streamId:{}",
-								firstPacketDtsMs, firstAudioDtsForStream, pkt.dts(), streamId);
-
-					if ((pkt.dts() - firstAudioDtsForStream) < 0) {
-						firstAudioDtsForStream = pkt.dts();
-					}
-					firstAudioDtsMap.put(audioStreamIndex, firstAudioDtsForStream);
-					if (firstAudioDts == -1) {
-						firstAudioDts = firstAudioDtsForStream;
-					}
-				}
-				else {
-					firstAudioDtsForStream = storedFirstAudioDts;
-				}
-			}
-			
-			pkt.pts(av_rescale_q_rnd(pkt.pts() - firstAudioDtsForStream, inputTimebase, outputTimebase, AV_ROUND_NEAR_INF|AV_ROUND_PASS_MINMAX));
-			pkt.dts(av_rescale_q_rnd(pkt.dts() - firstAudioDtsForStream , inputTimebase, outputTimebase, AV_ROUND_NEAR_INF|AV_ROUND_PASS_MINMAX));
-
-
-			int ret = av_packet_ref(tmpPacket , pkt);
-			if (ret < 0) {
-				logger.error("Cannot copy audio packet for {}", streamId);
-				return;
-			}
-			writeAudioFrame(tmpPacket, inputTimebase, outputTimebase, context, dts);
-
-			av_packet_unref(tmpPacket);
+		if (codecType == AVMEDIA_TYPE_AUDIO) {
+			writeAudioPacket(pkt, inputTimebase, outputTimebase, context, originalTiming.dts());
 		}
-		else if (codecType == AVMEDIA_TYPE_VIDEO)
-		{
-			//removing firstVideoDts is required when recording/muxing has started on the fly
-			pkt.pts(av_rescale_q_rnd(pkt.pts() - firstVideoDts , inputTimebase, outputTimebase, AV_ROUND_NEAR_INF|AV_ROUND_PASS_MINMAX));
-			pkt.dts(av_rescale_q_rnd(pkt.dts() - firstVideoDts, inputTimebase, outputTimebase, AV_ROUND_NEAR_INF|AV_ROUND_PASS_MINMAX));
-
-			//we set the firstVideoDts in checkToDropPacket Method to not have audio/video synch issue
-
-			// we don't set startTimeInVideoTimebase here because we only start with key frame and we drop all frames
-			// until the first key frame
-			boolean isKeyFrame = (pkt.flags() & AV_PKT_FLAG_KEY) == 1;
-
-            int ret = av_packet_ref(tmpPacket , pkt);
-			if (ret < 0) {
-				logger.error("Cannot copy video packet for {}", streamId);
-				return;
-			}			
-			/*
-			 * We add this check because when encoder calls this method the packet needs extra data inside
-			 * However, SFUForwarder calls writeVideoBuffer and the method packets itself there
-			 * To prevent memory issues and crashes we don't repacket if the packet is ready to use from SFU forwarder
-			 */
-			addExtradataIfRequired(pkt, isKeyFrame);
-
-			lastPts = tmpPacket.pts();
-
-			writeVideoFrame(tmpPacket, context);
-			av_packet_unref(tmpPacket);
+		else if (codecType == AVMEDIA_TYPE_VIDEO) {
+			writeVideoPacket(pkt, inputTimebase, outputTimebase, context);
 		}
 		else {
-			//for any other stream like subtitle, etc.
-			pkt.pts(av_rescale_q_rnd(pkt.pts(), inputTimebase, outputTimebase, AV_ROUND_NEAR_INF|AV_ROUND_PASS_MINMAX));
-			pkt.dts(av_rescale_q_rnd(pkt.dts(), inputTimebase, outputTimebase, AV_ROUND_NEAR_INF|AV_ROUND_PASS_MINMAX));
-
-			writeDataFrame(pkt, context);
+			writeOtherPacket(pkt, inputTimebase, outputTimebase, context);
 		}
 
-		pkt.pts(pts);
-		pkt.dts(dts);
-		pkt.duration(duration);
-		pkt.pos(pos);
-
+		restorePacketTiming(pkt, originalTiming);
 	}
+
+	private void writeAudioPacket(AVPacket pkt, AVRational inputTimebase, AVRational outputTimebase,
+			AVFormatContext context, long originalDts) {
+		long firstAudioDtsForStream = getFirstAudioDtsForStream(pkt, inputTimebase);
+		pkt.pts(av_rescale_q_rnd(pkt.pts() - firstAudioDtsForStream, inputTimebase, outputTimebase,
+				AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX));
+		pkt.dts(av_rescale_q_rnd(pkt.dts() - firstAudioDtsForStream, inputTimebase, outputTimebase,
+				AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX));
+
+		if (av_packet_ref(tmpPacket, pkt) < 0) {
+			logger.error("Cannot copy audio packet for {}", streamId);
+			return;
+		}
+		writeAudioFrame(tmpPacket, inputTimebase, outputTimebase, context, originalDts);
+		av_packet_unref(tmpPacket);
+	}
+
+	private long getFirstAudioDtsForStream(AVPacket pkt, AVRational inputTimebase) {
+		int audioStreamIndex = pkt.stream_index();
+		if (firstPacketDtsMs == -1) {
+			firstPacketDtsMs = av_rescale_q(pkt.dts(), inputTimebase, MuxAdaptor.TIME_BASE_FOR_MS);
+			firstAudioDtsMap.put(audioStreamIndex, pkt.dts());
+			firstAudioDts = pkt.dts();
+			logger.debug("The first incoming packet is audio and its packet dts:{}ms streamId:{} ", firstPacketDtsMs, streamId);
+			return pkt.dts();
+		}
+
+		Long storedFirstAudioDts = firstAudioDtsMap.get(audioStreamIndex);
+		if (storedFirstAudioDts != null) {
+			return storedFirstAudioDts;
+		}
+
+		long calculatedFirstAudioDts = av_rescale_q(firstPacketDtsMs, MuxAdaptor.TIME_BASE_FOR_MS, inputTimebase);
+		logger.debug("First packetDtsMs:{}ms is already received calculated the firstAudioDts:{} and incoming packet dts:{} streamId:{}",
+				firstPacketDtsMs, calculatedFirstAudioDts, pkt.dts(), streamId);
+		calculatedFirstAudioDts = Math.min(calculatedFirstAudioDts, pkt.dts());
+		firstAudioDtsMap.put(audioStreamIndex, calculatedFirstAudioDts);
+		if (firstAudioDts == -1) {
+			firstAudioDts = calculatedFirstAudioDts;
+		}
+		return calculatedFirstAudioDts;
+	}
+
+	private void writeVideoPacket(AVPacket pkt, AVRational inputTimebase, AVRational outputTimebase,
+			AVFormatContext context) {
+		pkt.pts(av_rescale_q_rnd(pkt.pts() - firstVideoDts, inputTimebase, outputTimebase,
+				AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX));
+		pkt.dts(av_rescale_q_rnd(pkt.dts() - firstVideoDts, inputTimebase, outputTimebase,
+				AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX));
+		if (av_packet_ref(tmpPacket, pkt) < 0) {
+			logger.error("Cannot copy video packet for {}", streamId);
+			return;
+		}
+		addExtradataIfRequired(pkt, (pkt.flags() & AV_PKT_FLAG_KEY) == 1);
+		lastPts = tmpPacket.pts();
+		writeVideoFrame(tmpPacket, context);
+		av_packet_unref(tmpPacket);
+	}
+
+	private void writeOtherPacket(AVPacket pkt, AVRational inputTimebase, AVRational outputTimebase,
+			AVFormatContext context) {
+		pkt.pts(av_rescale_q_rnd(pkt.pts(), inputTimebase, outputTimebase,
+				AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX));
+		pkt.dts(av_rescale_q_rnd(pkt.dts(), inputTimebase, outputTimebase,
+				AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX));
+		writeDataFrame(pkt, context);
+	}
+
+	private void restorePacketTiming(AVPacket pkt, PacketTiming timing) {
+		pkt.pts(timing.pts());
+		pkt.dts(timing.dts());
+		pkt.duration(timing.duration());
+		pkt.pos(timing.position());
+	}
+
+	private record PacketTiming(long pts, long dts, long duration, long position) { }
 
 	public void writeDataFrame(AVPacket pkt, AVFormatContext context) {
 		int ret = av_packet_ref(tmpPacket , pkt);

--- a/src/main/java/io/antmedia/muxer/WebVttCue.java
+++ b/src/main/java/io/antmedia/muxer/WebVttCue.java
@@ -1,0 +1,23 @@
+package io.antmedia.muxer;
+
+/**
+ * A WebVTT cue on the media timeline.
+ *
+ * @param startTimeMs cue start in milliseconds
+ * @param endTimeMs cue end in milliseconds
+ * @param text cue payload
+ */
+public record WebVttCue(long startTimeMs, long endTimeMs, String text) {
+
+	public WebVttCue {
+		if (startTimeMs < 0) {
+			throw new IllegalArgumentException("startTimeMs cannot be negative");
+		}
+		if (endTimeMs <= startTimeMs) {
+			throw new IllegalArgumentException("endTimeMs must be greater than startTimeMs");
+		}
+		if (text == null || text.isBlank()) {
+			throw new IllegalArgumentException("text cannot be blank");
+		}
+	}
+}

--- a/src/main/java/io/antmedia/muxer/WebVttHlsPlaylist.java
+++ b/src/main/java/io/antmedia/muxer/WebVttHlsPlaylist.java
@@ -1,0 +1,192 @@
+package io.antmedia.muxer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import io.lindstrom.m3u8.model.MediaSegment;
+import io.lindstrom.m3u8.parser.MediaPlaylistParser;
+import io.lindstrom.m3u8.parser.PlaylistParserException;
+
+/**
+ * Writes one WebVTT HLS rendition by mirroring the segment boundaries of the
+ * primary media playlist.
+ */
+class WebVttHlsPlaylist {
+
+	private final WebVttTrack track;
+	private final File directory;
+	private final String baseName;
+	private final File playlistFile;
+	private final List<WebVttCue> cues = new ArrayList<>();
+	private final Map<Long, Segment> knownSegments = new HashMap<>();
+	private final Set<Long> writtenSequences = new HashSet<>();
+	private TimelinePlaylist mediaPlaylist;
+
+	WebVttHlsPlaylist(WebVttTrack track, File directory, String baseName) {
+		this.track = track;
+		this.directory = directory;
+		this.baseName = baseName;
+		playlistFile = new File(directory, playlistName(track, baseName));
+	}
+
+	WebVttTrack track() {
+		return track;
+	}
+
+	String playlistName() {
+		return playlistFile.getName();
+	}
+
+	synchronized void addCue(WebVttCue cue) throws IOException {
+		cues.add(cue);
+		if (mediaPlaylist != null) {
+			writeFiles();
+		}
+	}
+
+	synchronized void update(String mediaPlaylistContent) throws IOException {
+		TimelinePlaylist parsed;
+		try {
+			parsed = parseMediaPlaylist(mediaPlaylistContent);
+		}
+		catch (PlaylistParserException e) {
+			throw new IOException("Cannot parse media playlist", e);
+		}
+		if (parsed.segments().isEmpty()) {
+			return;
+		}
+		mediaPlaylist = addTimeline(parsed);
+		writeFiles();
+	}
+
+	private TimelinePlaylist addTimeline(TimelinePlaylist parsed) {
+		List<Segment> segments = new ArrayList<>();
+		long startMs = findStartTime(parsed);
+		for (Segment segment : parsed.segments()) {
+			Segment timedSegment = new Segment(segment.sequence(), startMs, segment.durationMs());
+			knownSegments.put(timedSegment.sequence(), timedSegment);
+			segments.add(timedSegment);
+			startMs += timedSegment.durationMs();
+		}
+		return new TimelinePlaylist(parsed.version(), parsed.targetDuration(), parsed.mediaSequence(), segments,
+				parsed.endList());
+	}
+
+	private long findStartTime(TimelinePlaylist parsed) {
+		Segment first = knownSegments.get(parsed.mediaSequence());
+		if (first != null) {
+			return first.startMs();
+		}
+		Segment previous = knownSegments.get(parsed.mediaSequence() - 1);
+		if (previous != null) {
+			return previous.startMs() + previous.durationMs();
+		}
+		return knownSegments.isEmpty() ? 0 : knownSegments.values().stream()
+				.max((left, right) -> Long.compare(left.sequence(), right.sequence()))
+				.map(segment -> segment.startMs() + segment.durationMs()).orElse(0L);
+	}
+
+	private void writeFiles() throws IOException {
+		for (Segment segment : mediaPlaylist.segments()) {
+			writeAtomically(new File(directory, segmentName(segment.sequence())), createSegmentContent(segment));
+			writtenSequences.add(segment.sequence());
+		}
+		writeAtomically(playlistFile, createPlaylistContent());
+		removeExpiredFiles();
+		long earliestCueTime = mediaPlaylist.segments().get(0).startMs();
+		cues.removeIf(cue -> cue.endTimeMs() < earliestCueTime);
+	}
+
+	private String createSegmentContent(Segment segment) {
+		StringBuilder content = new StringBuilder("WEBVTT\n");
+		long segmentEnd = segment.startMs() + segment.durationMs();
+		for (WebVttCue cue : cues) {
+			if (cue.startTimeMs() >= segment.startMs() && cue.startTimeMs() < segmentEnd) {
+				content.append('\n').append(formatTimestamp(cue.startTimeMs())).append(" --> ")
+						.append(formatTimestamp(cue.endTimeMs())).append('\n').append(cue.text()).append('\n');
+			}
+		}
+		return content.toString();
+	}
+
+	private String createPlaylistContent() {
+		io.lindstrom.m3u8.model.MediaPlaylist.Builder builder = io.lindstrom.m3u8.model.MediaPlaylist.builder()
+				.version(mediaPlaylist.version())
+				.targetDuration(mediaPlaylist.targetDuration())
+				.mediaSequence(mediaPlaylist.mediaSequence())
+				.ongoing(!mediaPlaylist.endList());
+		for (Segment segment : mediaPlaylist.segments()) {
+			builder.addMediaSegments(MediaSegment.builder()
+					.duration(segment.durationMs() / 1000D)
+					.uri(segmentName(segment.sequence()))
+					.build());
+		}
+		return new MediaPlaylistParser().writePlaylistAsString(builder.build());
+	}
+
+	private void removeExpiredFiles() throws IOException {
+		long firstSequenceToKeep = Math.max(0, mediaPlaylist.mediaSequence() - 1);
+		for (Long sequence : new HashSet<>(writtenSequences)) {
+			if (sequence < firstSequenceToKeep) {
+				Files.deleteIfExists(new File(directory, segmentName(sequence)).toPath());
+				writtenSequences.remove(sequence);
+				knownSegments.remove(sequence);
+			}
+		}
+	}
+
+	private String segmentName(long sequence) {
+		return baseName + "_subtitles_" + track.inputStreamIndex() + "_" + sequence + ".vtt";
+	}
+
+	static String playlistName(WebVttTrack track, String baseName) {
+		return baseName + "_subtitles_" + track.inputStreamIndex() + ".m3u8";
+	}
+
+	static TimelinePlaylist parseMediaPlaylist(String content) throws PlaylistParserException {
+		io.lindstrom.m3u8.model.MediaPlaylist source = new MediaPlaylistParser().readPlaylist(content);
+		long sequence = source.mediaSequence();
+		List<Segment> segments = new ArrayList<>();
+		for (MediaSegment segment : source.mediaSegments()) {
+			segments.add(new Segment(sequence++, 0, Math.round(segment.duration() * 1000)));
+		}
+		return new TimelinePlaylist(source.version().orElse(3), source.targetDuration(), source.mediaSequence(),
+				segments, !source.ongoing());
+	}
+
+	private static String formatTimestamp(long timestampMs) {
+		long hours = timestampMs / 3_600_000;
+		long minutes = timestampMs % 3_600_000 / 60_000;
+		long seconds = timestampMs % 60_000 / 1_000;
+		long milliseconds = timestampMs % 1_000;
+		return String.format(Locale.ROOT, "%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds);
+	}
+
+	private static void writeAtomically(File target, String content) throws IOException {
+		File temporary = new File(target.getParentFile(), target.getName() + ".tmp");
+		Files.writeString(temporary.toPath(), content, StandardCharsets.UTF_8);
+		try {
+			Files.move(temporary.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING,
+					StandardCopyOption.ATOMIC_MOVE);
+		}
+		catch (AtomicMoveNotSupportedException e) {
+			Files.move(temporary.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+		}
+	}
+
+	record Segment(long sequence, long startMs, long durationMs) { }
+
+	record TimelinePlaylist(int version, int targetDuration, long mediaSequence, List<Segment> segments,
+			boolean endList) { }
+}

--- a/src/main/java/io/antmedia/muxer/WebVttMasterPlaylistSynchronizer.java
+++ b/src/main/java/io/antmedia/muxer/WebVttMasterPlaylistSynchronizer.java
@@ -1,0 +1,56 @@
+package io.antmedia.muxer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Adds AMS-generated WebVTT renditions after FFmpeg creates or rewrites an HLS master playlist.
+ */
+class WebVttMasterPlaylistSynchronizer {
+
+	private final File masterPlaylist;
+	private final Collection<WebVttTrack> tracks;
+	private final String baseName;
+	private long lastModified = -1;
+	private long lastSize = -1;
+	private String mediaPlaylistName;
+
+	WebVttMasterPlaylistSynchronizer(File masterPlaylist, Collection<WebVttTrack> tracks, String baseName) {
+		this.masterPlaylist = masterPlaylist;
+		this.tracks = tracks;
+		this.baseName = baseName;
+	}
+
+	Optional<String> synchronize(boolean force) throws IOException {
+		if (!masterPlaylist.isFile()) {
+			return Optional.empty();
+		}
+		long modified = masterPlaylist.lastModified();
+		long size = masterPlaylist.length();
+		if (!force && modified == lastModified && size == lastSize) {
+			return Optional.ofNullable(mediaPlaylistName);
+		}
+
+		// Remember failures as well. FFmpeg's next completed rewrite changes these values and retries the merge,
+		// while a permanently malformed file does not cause one warning for every video packet.
+		lastModified = modified;
+		lastSize = size;
+		String source = Files.readString(masterPlaylist.toPath(), StandardCharsets.UTF_8);
+		mediaPlaylistName = HLSMuxer.getPrimaryVariantUri(source);
+		String merged = HLSMuxer.addWebVttToMasterPlaylistContent(tracks, baseName, source);
+		if (!merged.equals(source)) {
+			File temporaryFile = new File(masterPlaylist.getParentFile(), masterPlaylist.getName() + ".tmp");
+			Files.writeString(temporaryFile.toPath(), merged, StandardCharsets.UTF_8);
+			Files.move(temporaryFile.toPath(), masterPlaylist.toPath(), StandardCopyOption.REPLACE_EXISTING,
+					StandardCopyOption.ATOMIC_MOVE);
+			lastModified = masterPlaylist.lastModified();
+			lastSize = masterPlaylist.length();
+		}
+		return Optional.of(mediaPlaylistName);
+	}
+}

--- a/src/main/java/io/antmedia/muxer/WebVttTrack.java
+++ b/src/main/java/io/antmedia/muxer/WebVttTrack.java
@@ -1,0 +1,19 @@
+package io.antmedia.muxer;
+
+/**
+ * Describes a WebVTT subtitle track created from an ingest stream.
+ *
+ * @param inputStreamIndex source stream index used to route cues
+ * @param language BCP 47 language code, or {@code und}
+ * @param name human-readable track name
+ */
+public record WebVttTrack(int inputStreamIndex, String language, String name) {
+
+	public WebVttTrack {
+		if (inputStreamIndex < 0) {
+			throw new IllegalArgumentException("inputStreamIndex cannot be negative");
+		}
+		language = language == null || language.isBlank() ? "und" : language;
+		name = name == null || name.isBlank() ? "Subtitles" : name;
+	}
+}

--- a/src/test/java/io/antmedia/muxer/HLSMuxerTest.java
+++ b/src/test/java/io/antmedia/muxer/HLSMuxerTest.java
@@ -1,13 +1,18 @@
 package io.antmedia.muxer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.bytedeco.ffmpeg.global.avutil.AVMEDIA_TYPE_DATA;
+import static org.bytedeco.ffmpeg.global.avutil.AVMEDIA_TYPE_SUBTITLE;
 import static org.mockito.Mockito.mock;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
+import java.util.List;
 
+import org.bytedeco.ffmpeg.avcodec.AVPacket;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -20,6 +25,11 @@ class HLSMuxerTest extends UnitTestBase<HLSMuxer> {
 
 	@TempDir
 	Path tempDirectory;
+
+	@BeforeEach
+	void setUp() {
+		classUnderTest = new HLSMuxer(null, null, "streams", 0, null, false);
+	}
 
 	@Test
 	void shouldOnlyFinalizeFilesModifiedBeforeCleanupWasScheduled() throws Exception {
@@ -42,5 +52,42 @@ class HLSMuxerTest extends UnitTestBase<HLSMuxer> {
 		Path file = Files.createFile(tempDirectory.resolve(fileName));
 		Files.setLastModifiedTime(file, FileTime.from(modificationTime));
 		return file;
+	}
+
+	@Test
+	void testCreateMultiTrackWebVttMasterPlaylistContent() {
+		WebVttTrack german = new WebVttTrack(2, "deu\n", "DVB \"TTML\"");
+		WebVttTrack french = new WebVttTrack(3, "fra", "Hard of hearing");
+
+		String playlist = HLSMuxer.createWebVttMasterPlaylistContent(List.of(french, german), "test", "test.m3u8");
+
+		assertThat(playlist)
+				.startsWith("#EXTM3U\n")
+				.contains("LANGUAGE=\"deu \"", "NAME=\"DVB 'TTML'\"", "DEFAULT=YES")
+				.contains("URI=\"test_subtitles_2.m3u8\"")
+				.contains("LANGUAGE=\"fra\"", "NAME=\"Hard of hearing\"", "DEFAULT=NO")
+				.contains("URI=\"test_subtitles_3.m3u8\"")
+				.containsOnlyOnce("DEFAULT=YES")
+				.endsWith("test.m3u8\n");
+	}
+
+	@Test
+	void testDropsOriginalDataPacketForConvertedTrack() {
+		try (AVPacket packet = new AVPacket()) {
+			packet.stream_index(2);
+			assertThat(classUnderTest.checkToDropPacket(packet, AVMEDIA_TYPE_DATA)).isFalse();
+
+			classUnderTest.setWebVttTracks(List.of(
+					new WebVttTrack(2, "de", "German"), new WebVttTrack(3, "fr", "French")));
+
+			assertThat(classUnderTest.checkToDropPacket(packet, AVMEDIA_TYPE_DATA)).isTrue();
+			assertThat(classUnderTest.checkToDropPacket(packet, AVMEDIA_TYPE_SUBTITLE)).isFalse();
+
+			packet.stream_index(3);
+			assertThat(classUnderTest.checkToDropPacket(packet, AVMEDIA_TYPE_DATA)).isTrue();
+
+			packet.stream_index(4);
+			assertThat(classUnderTest.checkToDropPacket(packet, AVMEDIA_TYPE_DATA)).isFalse();
+		}
 	}
 }

--- a/src/test/java/io/antmedia/muxer/HLSMuxerTest.java
+++ b/src/test/java/io/antmedia/muxer/HLSMuxerTest.java
@@ -5,6 +5,7 @@ import static org.bytedeco.ffmpeg.global.avutil.AVMEDIA_TYPE_DATA;
 import static org.bytedeco.ffmpeg.global.avutil.AVMEDIA_TYPE_SUBTITLE;
 import static org.mockito.Mockito.mock;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
@@ -69,6 +70,30 @@ class HLSMuxerTest extends UnitTestBase<HLSMuxer> {
 				.contains("URI=\"test_subtitles_3.m3u8\"")
 				.containsOnlyOnce("DEFAULT=YES")
 				.endsWith("test.m3u8\n");
+	}
+
+	@Test
+	void testAddWebVttTracksToMultiTrackAudioMasterPlaylist() throws IOException {
+		String audioMaster = "#EXTM3U\n#EXT-X-VERSION:3\n"
+				+ "#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"group_audio\",NAME=\"English\",DEFAULT=YES,"
+				+ "LANGUAGE=\"eng\",URI=\"test_audio_0.m3u8\"\n"
+				+ "#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"group_audio\",NAME=\"French\",DEFAULT=NO,"
+				+ "LANGUAGE=\"fra\",URI=\"test_fra.m3u8\"\n"
+				+ "#EXT-X-STREAM-INF:BANDWIDTH=1000000,AUDIO=\"group_audio\"\n"
+				+ "test_0.m3u8\n";
+
+		String combined = HLSMuxer.addWebVttToMasterPlaylistContent(
+				List.of(new WebVttTrack(4, "eng", "English captions"),
+						new WebVttTrack(5, "fra", "French captions")), "test", audioMaster);
+
+		assertThat(combined)
+				.contains("TYPE=AUDIO", "URI=\"test_audio_0.m3u8\"", "URI=\"test_fra.m3u8\"")
+				.contains("TYPE=SUBTITLES", "URI=\"test_subtitles_4.m3u8\"",
+						"URI=\"test_subtitles_5.m3u8\"")
+				.contains("AUDIO=\"group_audio\"", "SUBTITLES=\"subs\"")
+				.endsWith("test_0.m3u8\n")
+				.doesNotContain("\ntest.m3u8\n");
+		assertThat(HLSMuxer.getPrimaryVariantUri(combined)).isEqualTo("test_0.m3u8");
 	}
 
 	@Test

--- a/src/test/java/io/antmedia/muxer/HLSMuxerTest.java
+++ b/src/test/java/io/antmedia/muxer/HLSMuxerTest.java
@@ -13,6 +13,7 @@ import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.bytedeco.ffmpeg.avcodec.AVPacket;
 import org.junit.jupiter.api.BeforeEach;
@@ -122,6 +123,47 @@ class HLSMuxerTest extends UnitTestBase<HLSMuxer> {
 			packet.stream_index(4);
 			assertThat(classUnderTest.checkToDropPacket(packet, AVMEDIA_TYPE_DATA)).isFalse();
 		}
+	}
+
+	@Test
+	void testWebVttPlaylistLifecycle() throws Exception {
+		Path mediaPlaylist = tempDirectory.resolve("test.m3u8");
+		ReflectionTestUtils.invokeMethod(classUnderTest, "syncWebVttPlaylists", false);
+		classUnderTest.file = mediaPlaylist.toFile();
+		classUnderTest.initialResourceNameWithoutExtension = "test";
+		classUnderTest.setIsRunning(new AtomicBoolean(true));
+
+		WebVttTrack track = new WebVttTrack(2, "de", "German");
+		classUnderTest.addWebVttTrack(track);
+		classUnderTest.writeWebVttCue(2, new WebVttCue(500, 1_500, "Hallo"));
+		classUnderTest.writeWebVttCue(3, new WebVttCue(500, 1_500, "Ignored"));
+		Path masterPlaylist = tempDirectory.resolve("test_master.m3u8");
+		ReflectionTestUtils.setField(classUnderTest, "webVttMasterPlaylist", masterPlaylist.toFile());
+		ReflectionTestUtils.invokeMethod(classUnderTest, "writeWebVttMasterPlaylist");
+		assertThat(Files.readString(masterPlaylist))
+				.contains("TYPE=SUBTITLES", "URI=\"test_subtitles_2.m3u8\"", "test.m3u8");
+
+		Files.writeString(mediaPlaylist, """
+				#EXTM3U
+				#EXT-X-VERSION:3
+				#EXT-X-TARGETDURATION:2
+				#EXT-X-MEDIA-SEQUENCE:10
+				#EXTINF:2.000000,
+				test000000010.ts
+				""");
+		ReflectionTestUtils.setField(classUnderTest, "webVttMediaPlaylist", mediaPlaylist.toFile());
+
+		ReflectionTestUtils.invokeMethod(classUnderTest, "syncWebVttPlaylists", false);
+		ReflectionTestUtils.invokeMethod(classUnderTest, "syncWebVttPlaylists", false);
+
+		assertThat(Files.readString(tempDirectory.resolve("test_subtitles_2.m3u8")))
+				.contains("#EXT-X-MEDIA-SEQUENCE:10", "test_subtitles_2_10.vtt");
+		assertThat(Files.readString(tempDirectory.resolve("test_subtitles_2_10.vtt")))
+				.contains("00:00:00.500 --> 00:00:01.500", "Hallo")
+				.doesNotContain("Ignored");
+
+		classUnderTest.setIsRunning(new AtomicBoolean(false));
+		classUnderTest.writeWebVttCue(2, new WebVttCue(1_600, 1_900, "Too late"));
 	}
 
 	@Test

--- a/src/test/java/io/antmedia/muxer/HLSMuxerTest.java
+++ b/src/test/java/io/antmedia/muxer/HLSMuxerTest.java
@@ -1,6 +1,7 @@
 package io.antmedia.muxer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.bytedeco.ffmpeg.global.avutil.AVMEDIA_TYPE_DATA;
 import static org.bytedeco.ffmpeg.global.avutil.AVMEDIA_TYPE_SUBTITLE;
 import static org.mockito.Mockito.mock;
@@ -74,13 +75,16 @@ class HLSMuxerTest extends UnitTestBase<HLSMuxer> {
 
 	@Test
 	void testAddWebVttTracksToMultiTrackAudioMasterPlaylist() throws IOException {
-		String audioMaster = "#EXTM3U\n#EXT-X-VERSION:3\n"
-				+ "#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"group_audio\",NAME=\"English\",DEFAULT=YES,"
-				+ "LANGUAGE=\"eng\",URI=\"test_audio_0.m3u8\"\n"
-				+ "#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"group_audio\",NAME=\"French\",DEFAULT=NO,"
-				+ "LANGUAGE=\"fra\",URI=\"test_fra.m3u8\"\n"
-				+ "#EXT-X-STREAM-INF:BANDWIDTH=1000000,AUDIO=\"group_audio\"\n"
-				+ "test_0.m3u8\n";
+		String audioMaster = """
+				#EXTM3U
+				#EXT-X-VERSION:3
+				#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="group_audio",NAME="English",DEFAULT=YES,LANGUAGE="eng",URI="test_audio_0.m3u8"
+				#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="group_audio",NAME="French",DEFAULT=NO,LANGUAGE="fra",URI="test_fra.m3u8"
+				#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="Obsolete",DEFAULT=YES,URI="old.m3u8"
+				#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="other",NAME="External",DEFAULT=NO,URI="external.m3u8"
+				#EXT-X-STREAM-INF:BANDWIDTH=1000000,AUDIO="group_audio"
+				test_0.m3u8
+				""";
 
 		String combined = HLSMuxer.addWebVttToMasterPlaylistContent(
 				List.of(new WebVttTrack(4, "eng", "English captions"),
@@ -89,11 +93,13 @@ class HLSMuxerTest extends UnitTestBase<HLSMuxer> {
 		assertThat(combined)
 				.contains("TYPE=AUDIO", "URI=\"test_audio_0.m3u8\"", "URI=\"test_fra.m3u8\"")
 				.contains("TYPE=SUBTITLES", "URI=\"test_subtitles_4.m3u8\"",
-						"URI=\"test_subtitles_5.m3u8\"")
+						"URI=\"test_subtitles_5.m3u8\"", "GROUP-ID=\"other\"", "URI=\"external.m3u8\"")
 				.contains("AUDIO=\"group_audio\"", "SUBTITLES=\"subs\"")
 				.endsWith("test_0.m3u8\n")
-				.doesNotContain("\ntest.m3u8\n");
+				.doesNotContain("\ntest.m3u8\n", "URI=\"old.m3u8\"");
 		assertThat(HLSMuxer.getPrimaryVariantUri(combined)).isEqualTo("test_0.m3u8");
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> HLSMuxer.getPrimaryVariantUri("#EXTM3U\n#EXT-X-VERSION:3\n"));
 	}
 
 	@Test

--- a/src/test/java/io/antmedia/muxer/HLSMuxerTest.java
+++ b/src/test/java/io/antmedia/muxer/HLSMuxerTest.java
@@ -12,12 +12,14 @@ import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 import org.bytedeco.ffmpeg.avcodec.AVPacket;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import io.antmedia.storage.StorageClient;
 import io.antmedia.test.UnitTestBase;
@@ -120,5 +122,53 @@ class HLSMuxerTest extends UnitTestBase<HLSMuxer> {
 			packet.stream_index(4);
 			assertThat(classUnderTest.checkToDropPacket(packet, AVMEDIA_TYPE_DATA)).isFalse();
 		}
+	}
+
+	@Test
+	void testBuildVariantStreamMap() {
+		assertThat(classUnderTest.buildVariantStreamMap(1, 2)).isEqualTo(
+				"v:0,agroup:audio a:0,agroup:audio,name:audio_0,language:und,default:yes a:1,agroup:audio,name:audio_1,language:und");
+		assertThat(classUnderTest.buildVariantStreamMap(0,
+				List.of(Optional.of("eng"), Optional.empty()))).isEqualTo(
+						"a:0,agroup:audio,name:eng,language:eng,default:yes a:1,agroup:audio,name:audio_1,language:und");
+	}
+
+	@Test
+	void testInsertVariantSpecifierBeforeExtension() {
+		assertThat(classUnderTest.insertVariantSpecifierBeforeExtension("stream.m3u8"))
+				.isEqualTo("stream_%v.m3u8");
+		assertThat(classUnderTest.insertVariantSpecifierBeforeExtension("stream_%v.m3u8"))
+				.isEqualTo("stream_%v.m3u8");
+		assertThat(classUnderTest.insertVariantSpecifierBeforeExtension("stream.ts"))
+				.isEqualTo("stream_%v.ts");
+		assertThat(classUnderTest.insertVariantSpecifierBeforeExtension("stream"))
+				.isEqualTo("stream_%v");
+	}
+
+	@Test
+	void testGetVariantSegmentFilename() {
+		ReflectionTestUtils.setField(classUnderTest, "segmentFileNameSuffix", "%09d");
+		ReflectionTestUtils.setField(classUnderTest, "segmentFilename", "streams/stream%09d.ts");
+		assertThat(classUnderTest.getVariantSegmentFilename()).isEqualTo("streams/stream_%v%09d.ts");
+
+		ReflectionTestUtils.setField(classUnderTest, "segmentFilename", "streams/stream.ts");
+		assertThat(classUnderTest.getVariantSegmentFilename()).isEqualTo("streams/stream_%v.ts");
+
+		ReflectionTestUtils.setField(classUnderTest, "segmentFilename", "streams/stream_%v%09d.ts");
+		assertThat(classUnderTest.getVariantSegmentFilename()).isEqualTo("streams/stream_%v%09d.ts");
+	}
+
+	@Test
+	void testVariantHlsFilePattern() {
+		String segmentFilename = "streams/stream_%v%09d.ts";
+		ReflectionTestUtils.setField(classUnderTest, "segmentFilename", segmentFilename);
+		ReflectionTestUtils.setField(classUnderTest, "variantStreamMappingEnabled", true);
+
+		String pattern = classUnderTest.getHLSFilesRegularExpression(segmentFilename.indexOf("%09d"));
+
+		assertThat("stream_0.m3u8").matches(pattern);
+		assertThat("stream_audio_0.m3u8").matches(pattern);
+		assertThat("stream_audio_000000001.vtt").matches(pattern);
+		assertThat("other_0.m3u8").doesNotMatch(pattern);
 	}
 }

--- a/src/test/java/io/antmedia/muxer/HLSMuxerTest.java
+++ b/src/test/java/io/antmedia/muxer/HLSMuxerTest.java
@@ -24,6 +24,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import io.antmedia.storage.StorageClient;
 import io.antmedia.test.UnitTestBase;
+import io.lindstrom.m3u8.model.AlternativeRendition;
+import io.lindstrom.m3u8.parser.MasterPlaylistParser;
 
 @Tag("fast")
 class HLSMuxerTest extends UnitTestBase<HLSMuxer> {
@@ -74,6 +76,66 @@ class HLSMuxerTest extends UnitTestBase<HLSMuxer> {
 				.contains("URI=\"test_subtitles_3.m3u8\"")
 				.containsOnlyOnce("DEFAULT=YES")
 				.endsWith("test.m3u8\n");
+	}
+
+	@Test
+	void testSubtitleNamesPreferMetadataLabels() throws IOException {
+		String playlist = HLSMuxer.createWebVttMasterPlaylistContent(List.of(
+				new WebVttTrack(3, "ara", "العربية"),
+				new WebVttTrack(4, "rus", "Russian captions")), "test", "test.m3u8");
+		assertThat(new MasterPlaylistParser().readPlaylist(playlist).alternativeRenditions())
+				.extracting(AlternativeRendition::name).containsExactly("العربية", "Russian captions");
+	}
+
+	@Test
+	void testGenericSubtitleNamesUseLanguageMetadata() throws IOException {
+		String playlist = HLSMuxer.createWebVttMasterPlaylistContent(List.of(
+				new WebVttTrack(4, "eng", "DVB-TTML"),
+				new WebVttTrack(5, "ara", "DVB-TTML"),
+				new WebVttTrack(6, "rus", "DVB-TTML")), "syncwords", "syncwords_0.m3u8");
+		var renditions = new MasterPlaylistParser().readPlaylist(playlist).alternativeRenditions();
+		assertThat(renditions).extracting(AlternativeRendition::name).containsExactly("English", "Arabic", "Russian");
+		assertThat(playlist).contains("LANGUAGE=\"eng\"", "LANGUAGE=\"ara\"", "LANGUAGE=\"rus\"")
+				.contains("syncwords_subtitles_4.m3u8", "syncwords_subtitles_5.m3u8", "syncwords_subtitles_6.m3u8")
+				.containsOnlyOnce("DEFAULT=YES").doesNotContain("DVB-TTML");
+	}
+
+	@Test
+	void testDuplicateSubtitleNamesDoNotTakeOtherMetadataLabels() throws IOException {
+		List<WebVttTrack> tracks = List.of(new WebVttTrack(5, "eng", "English (2)"),
+				new WebVttTrack(4, "eng", "DVB-TTML"), new WebVttTrack(3, "eng", "DVB-TTML"));
+		String playlist = HLSMuxer.createWebVttMasterPlaylistContent(tracks, "test", "test.m3u8");
+		assertThat(new MasterPlaylistParser().readPlaylist(playlist).alternativeRenditions())
+				.extracting(AlternativeRendition::name).containsExactly("English", "English (3)", "English (2)");
+		assertThat(HLSMuxer.createWebVttMasterPlaylistContent(List.of(tracks.get(2), tracks.get(0), tracks.get(1)),
+				"test", "test.m3u8")).isEqualTo(playlist);
+	}
+
+	@Test
+	void testSubtitleNamesAreUniqueAfterSanitizingMetadata() throws IOException {
+		String playlist = HLSMuxer.createWebVttMasterPlaylistContent(List.of(
+				new WebVttTrack(3, "eng", "News \"captions\""),
+				new WebVttTrack(4, "eng", "News 'captions'")), "test", "test.m3u8");
+		assertThat(new MasterPlaylistParser().readPlaylist(playlist).alternativeRenditions())
+				.extracting(AlternativeRendition::name).containsExactly("News 'captions'", "News 'captions' (2)");
+	}
+
+	@Test
+	void testMissingSubtitleMetadataFallsBackToUniqueNames() throws IOException {
+		String playlist = HLSMuxer.createWebVttMasterPlaylistContent(List.of(
+				new WebVttTrack(3, null, null), new WebVttTrack(4, "und", "DVB-TTML"),
+				new WebVttTrack(5, "ara", null)), "test", "test.m3u8");
+		assertThat(new MasterPlaylistParser().readPlaylist(playlist).alternativeRenditions())
+				.extracting(AlternativeRendition::name).containsExactly("Subtitles", "Subtitles (2)", "Arabic");
+	}
+
+	@Test
+	void testMergedMasterUsesUniqueSubtitleNames() throws IOException {
+		String master = "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1000000\ntest_0.m3u8\n";
+		String playlist = HLSMuxer.addWebVttToMasterPlaylistContent(List.of(
+				new WebVttTrack(3, "eng", "DVB-TTML"), new WebVttTrack(4, "ara", "DVB-TTML")), "test", master);
+		assertThat(new MasterPlaylistParser().readPlaylist(playlist).alternativeRenditions())
+				.extracting(AlternativeRendition::name).containsExactly("English", "Arabic");
 	}
 
 	@Test

--- a/src/test/java/io/antmedia/muxer/HLSMuxerTest.java
+++ b/src/test/java/io/antmedia/muxer/HLSMuxerTest.java
@@ -130,6 +130,26 @@ class HLSMuxerTest extends UnitTestBase<HLSMuxer> {
 	}
 
 	@Test
+	void testInvalidLanguageMetadataFallsBackToUniqueNames() throws IOException {
+		String playlist = HLSMuxer.createWebVttMasterPlaylistContent(List.of(
+				new WebVttTrack(3, "_", "DVB-TTML"),
+				new WebVttTrack(4, "_", "Subtitles")), "test", "test.m3u8");
+		assertThat(new MasterPlaylistParser().readPlaylist(playlist).alternativeRenditions())
+				.extracting(AlternativeRendition::name).containsExactly("Subtitles", "Subtitles (2)");
+	}
+
+	@Test
+	void testSubtitleLabelsNormalizeWhitespaceAndGenericNameCase() throws IOException {
+		String playlist = HLSMuxer.createWebVttMasterPlaylistContent(List.of(
+				new WebVttTrack(3, " eng ", " dvb-ttml "),
+				new WebVttTrack(4, "ara", " SUBTITLES "),
+				new WebVttTrack(5, " UND ", "\t\n"),
+				new WebVttTrack(6, "rus", " Russian captions ")), "test", "test.m3u8");
+		assertThat(new MasterPlaylistParser().readPlaylist(playlist).alternativeRenditions())
+				.extracting(AlternativeRendition::name).containsExactly("English", "Arabic", "Subtitles", "Russian captions");
+	}
+
+	@Test
 	void testMergedMasterUsesUniqueSubtitleNames() throws IOException {
 		String master = "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1000000\ntest_0.m3u8\n";
 		String playlist = HLSMuxer.addWebVttToMasterPlaylistContent(List.of(

--- a/src/test/java/io/antmedia/muxer/MuxAdaptorTest.java
+++ b/src/test/java/io/antmedia/muxer/MuxAdaptorTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import io.antmedia.test.UnitTestBase;
 
 @Tag("fast")
-public class MuxAdaptorTest extends UnitTestBase<MuxAdaptor> {
+class MuxAdaptorTest extends UnitTestBase<MuxAdaptor> {
 
 	private TestHLSMuxer hlsMuxer;
 

--- a/src/test/java/io/antmedia/muxer/MuxAdaptorTest.java
+++ b/src/test/java/io/antmedia/muxer/MuxAdaptorTest.java
@@ -1,0 +1,65 @@
+package io.antmedia.muxer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.antmedia.test.UnitTestBase;
+
+@Tag("fast")
+public class MuxAdaptorTest extends UnitTestBase<MuxAdaptor> {
+
+	private TestHLSMuxer hlsMuxer;
+
+	@BeforeEach
+	void setUp() {
+		classUnderTest = new MuxAdaptor(null);
+		hlsMuxer = new TestHLSMuxer();
+		classUnderTest.muxerList.add(hlsMuxer);
+	}
+
+	@Test
+	void testRegisterAndRouteMultipleWebVttTracks() {
+		classUnderTest.registerWebVttTrack(2, "de", "DVB-TTML");
+		classUnderTest.registerWebVttTrack(3, "fr", "Malentendants");
+		assertThat(hlsMuxer.tracks).containsExactly(
+				new WebVttTrack(2, "de", "DVB-TTML"), new WebVttTrack(3, "fr", "Malentendants"));
+
+		WebVttCue cue = new WebVttCue(1000, 2000, "Hello");
+		classUnderTest.writeWebVttCue(2, cue);
+		assertThat(hlsMuxer.cue).isEqualTo(cue);
+		assertThat(hlsMuxer.cueInputStreamIndex).isEqualTo(2);
+
+		classUnderTest.writeWebVttCue(3, cue);
+		assertThat(hlsMuxer.cueCallCount).isEqualTo(2);
+
+		classUnderTest.writeWebVttCue(4, cue);
+		assertThat(hlsMuxer.cueCallCount).isEqualTo(2);
+	}
+
+	private static class TestHLSMuxer extends HLSMuxer {
+
+		private final java.util.List<WebVttTrack> tracks = new java.util.ArrayList<>();
+		private WebVttCue cue;
+		private int cueInputStreamIndex = -1;
+		private int cueCallCount;
+
+		TestHLSMuxer() {
+			super(null, null, "streams", 0, null, false);
+		}
+
+		@Override
+		public void addWebVttTrack(WebVttTrack track) {
+			tracks.add(track);
+		}
+
+		@Override
+		public synchronized void writeWebVttCue(int inputStreamIndex, WebVttCue cue) {
+			this.cueInputStreamIndex = inputStreamIndex;
+			this.cue = cue;
+			cueCallCount++;
+		}
+	}
+}

--- a/src/test/java/io/antmedia/muxer/WebVttCueTest.java
+++ b/src/test/java/io/antmedia/muxer/WebVttCueTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import io.antmedia.test.UnitTestBase;
 
 @Tag("fast")
-public class WebVttCueTest extends UnitTestBase<WebVttCue> {
+class WebVttCueTest extends UnitTestBase<WebVttCue> {
 
 	@Test
 	void testValidCue() {

--- a/src/test/java/io/antmedia/muxer/WebVttCueTest.java
+++ b/src/test/java/io/antmedia/muxer/WebVttCueTest.java
@@ -1,0 +1,29 @@
+package io.antmedia.muxer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.antmedia.test.UnitTestBase;
+
+@Tag("fast")
+public class WebVttCueTest extends UnitTestBase<WebVttCue> {
+
+	@Test
+	void testValidCue() {
+		classUnderTest = new WebVttCue(1200, 3400, "Hello");
+
+		assertThat(classUnderTest.startTimeMs()).isEqualTo(1200);
+		assertThat(classUnderTest.endTimeMs()).isEqualTo(3400);
+		assertThat(classUnderTest.text()).isEqualTo("Hello");
+	}
+
+	@Test
+	void testRejectInvalidCue() {
+		assertThatIllegalArgumentException().isThrownBy(() -> new WebVttCue(-1, 1000, "Hello"));
+		assertThatIllegalArgumentException().isThrownBy(() -> new WebVttCue(1000, 1000, "Hello"));
+		assertThatIllegalArgumentException().isThrownBy(() -> new WebVttCue(1000, 2000, " "));
+	}
+}

--- a/src/test/java/io/antmedia/muxer/WebVttHlsPlaylistTest.java
+++ b/src/test/java/io/antmedia/muxer/WebVttHlsPlaylistTest.java
@@ -1,0 +1,39 @@
+package io.antmedia.muxer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.antmedia.test.UnitTestBase;
+
+@Tag("fast")
+public class WebVttHlsPlaylistTest extends UnitTestBase<WebVttHlsPlaylist> {
+
+	@TempDir
+	Path temporaryDirectory;
+
+	@Test
+	void testMirrorMediaSegmentsAndWriteCues() throws Exception {
+		classUnderTest = new WebVttHlsPlaylist(new WebVttTrack(3, "fra", "French"),
+				temporaryDirectory.toFile(), "test");
+		classUnderTest.addCue(new WebVttCue(500, 2500, "Bonjour"));
+		classUnderTest.addCue(new WebVttCue(2200, 3100, "Deuxième"));
+
+		classUnderTest.update("#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:2\n"
+				+ "#EXT-X-MEDIA-SEQUENCE:10\n#EXTINF:2.000000,\ntest10.ts\n"
+				+ "#EXTINF:2.000000,\ntest11.ts\n");
+
+		assertThat(Files.readString(temporaryDirectory.resolve("test_subtitles_3.m3u8")))
+				.contains("#EXT-X-MEDIA-SEQUENCE:10", "test_subtitles_3_10.vtt", "test_subtitles_3_11.vtt");
+		assertThat(Files.readString(temporaryDirectory.resolve("test_subtitles_3_10.vtt")))
+				.contains("00:00:00.500 --> 00:00:02.500", "Bonjour")
+				.doesNotContain("Deuxième");
+		assertThat(Files.readString(temporaryDirectory.resolve("test_subtitles_3_11.vtt")))
+				.contains("00:00:02.200 --> 00:00:03.100", "Deuxième");
+	}
+}

--- a/src/test/java/io/antmedia/muxer/WebVttHlsPlaylistTest.java
+++ b/src/test/java/io/antmedia/muxer/WebVttHlsPlaylistTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.io.TempDir;
 import io.antmedia.test.UnitTestBase;
 
 @Tag("fast")
-public class WebVttHlsPlaylistTest extends UnitTestBase<WebVttHlsPlaylist> {
+class WebVttHlsPlaylistTest extends UnitTestBase<WebVttHlsPlaylist> {
 
 	@TempDir
 	Path temporaryDirectory;
@@ -24,9 +24,16 @@ public class WebVttHlsPlaylistTest extends UnitTestBase<WebVttHlsPlaylist> {
 		classUnderTest.addCue(new WebVttCue(500, 2500, "Bonjour"));
 		classUnderTest.addCue(new WebVttCue(2200, 3100, "Deuxième"));
 
-		classUnderTest.update("#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:2\n"
-				+ "#EXT-X-MEDIA-SEQUENCE:10\n#EXTINF:2.000000,\ntest10.ts\n"
-				+ "#EXTINF:2.000000,\ntest11.ts\n");
+		classUnderTest.update("""
+				#EXTM3U
+				#EXT-X-VERSION:3
+				#EXT-X-TARGETDURATION:2
+				#EXT-X-MEDIA-SEQUENCE:10
+				#EXTINF:2.000000,
+				test10.ts
+				#EXTINF:2.000000,
+				test11.ts
+				""");
 
 		assertThat(Files.readString(temporaryDirectory.resolve("test_subtitles_3.m3u8")))
 				.contains("#EXT-X-MEDIA-SEQUENCE:10", "test_subtitles_3_10.vtt", "test_subtitles_3_11.vtt");

--- a/src/test/java/io/antmedia/muxer/WebVttMasterPlaylistSynchronizerTest.java
+++ b/src/test/java/io/antmedia/muxer/WebVttMasterPlaylistSynchronizerTest.java
@@ -17,11 +17,13 @@ import io.antmedia.test.UnitTestBase;
 @Tag("fast")
 class WebVttMasterPlaylistSynchronizerTest extends UnitTestBase<WebVttMasterPlaylistSynchronizer> {
 
-	private static final String FFMPEG_MASTER = "#EXTM3U\n#EXT-X-VERSION:3\n"
-			+ "#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"group_audio\",NAME=\"English\",DEFAULT=YES,"
-			+ "LANGUAGE=\"eng\",URI=\"test_audio_0.m3u8\"\n"
-			+ "#EXT-X-STREAM-INF:BANDWIDTH=1000000,AUDIO=\"group_audio\"\n"
-			+ "test_0.m3u8\n";
+	private static final String FFMPEG_MASTER = """
+			#EXTM3U
+			#EXT-X-VERSION:3
+			#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="group_audio",NAME="English",DEFAULT=YES,LANGUAGE="eng",URI="test_audio_0.m3u8"
+			#EXT-X-STREAM-INF:BANDWIDTH=1000000,AUDIO="group_audio"
+			test_0.m3u8
+			""";
 
 	@TempDir
 	Path tempDirectory;
@@ -40,6 +42,8 @@ class WebVttMasterPlaylistSynchronizerTest extends UnitTestBase<WebVttMasterPlay
 
 		FileTime mergedModificationTime = Files.getLastModifiedTime(master);
 		assertThat(classUnderTest.synchronize(false)).contains("test_0.m3u8");
+		assertThat(Files.getLastModifiedTime(master)).isEqualTo(mergedModificationTime);
+		assertThat(classUnderTest.synchronize(true)).contains("test_0.m3u8");
 		assertThat(Files.getLastModifiedTime(master)).isEqualTo(mergedModificationTime);
 
 		Files.writeString(master, FFMPEG_MASTER, StandardCharsets.UTF_8);

--- a/src/test/java/io/antmedia/muxer/WebVttMasterPlaylistSynchronizerTest.java
+++ b/src/test/java/io/antmedia/muxer/WebVttMasterPlaylistSynchronizerTest.java
@@ -1,0 +1,50 @@
+package io.antmedia.muxer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.antmedia.test.UnitTestBase;
+
+@Tag("fast")
+class WebVttMasterPlaylistSynchronizerTest extends UnitTestBase<WebVttMasterPlaylistSynchronizer> {
+
+	private static final String FFMPEG_MASTER = "#EXTM3U\n#EXT-X-VERSION:3\n"
+			+ "#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"group_audio\",NAME=\"English\",DEFAULT=YES,"
+			+ "LANGUAGE=\"eng\",URI=\"test_audio_0.m3u8\"\n"
+			+ "#EXT-X-STREAM-INF:BANDWIDTH=1000000,AUDIO=\"group_audio\"\n"
+			+ "test_0.m3u8\n";
+
+	@TempDir
+	Path tempDirectory;
+
+	@Test
+	void testSynchronizeAfterDelayedCreationAndFfmpegRewrite() throws Exception {
+		Path master = tempDirectory.resolve("test.m3u8");
+		classUnderTest = new WebVttMasterPlaylistSynchronizer(master.toFile(),
+				List.of(new WebVttTrack(2, "eng", "English captions")), "test");
+
+		assertThat(classUnderTest.synchronize(false)).isEmpty();
+
+		Files.writeString(master, FFMPEG_MASTER, StandardCharsets.UTF_8);
+		assertThat(classUnderTest.synchronize(false)).contains("test_0.m3u8");
+		assertThat(Files.readString(master)).contains("TYPE=AUDIO", "TYPE=SUBTITLES", "SUBTITLES=\"subs\"");
+
+		FileTime mergedModificationTime = Files.getLastModifiedTime(master);
+		assertThat(classUnderTest.synchronize(false)).contains("test_0.m3u8");
+		assertThat(Files.getLastModifiedTime(master)).isEqualTo(mergedModificationTime);
+
+		Files.writeString(master, FFMPEG_MASTER, StandardCharsets.UTF_8);
+		Files.setLastModifiedTime(master, FileTime.fromMillis(mergedModificationTime.toMillis() + 1_000));
+		assertThat(classUnderTest.synchronize(false)).contains("test_0.m3u8");
+		assertThat(Files.readString(master)).contains("TYPE=SUBTITLES", "SUBTITLES=\"subs\"");
+	}
+}

--- a/src/test/java/io/antmedia/muxer/WebVttTrackTest.java
+++ b/src/test/java/io/antmedia/muxer/WebVttTrackTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import io.antmedia.test.UnitTestBase;
 
 @Tag("fast")
-public class WebVttTrackTest extends UnitTestBase<WebVttTrack> {
+class WebVttTrackTest extends UnitTestBase<WebVttTrack> {
 
 	@Test
 	void testDefaults() {

--- a/src/test/java/io/antmedia/muxer/WebVttTrackTest.java
+++ b/src/test/java/io/antmedia/muxer/WebVttTrackTest.java
@@ -1,0 +1,27 @@
+package io.antmedia.muxer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.antmedia.test.UnitTestBase;
+
+@Tag("fast")
+public class WebVttTrackTest extends UnitTestBase<WebVttTrack> {
+
+	@Test
+	void testDefaults() {
+		classUnderTest = new WebVttTrack(2, null, " ");
+
+		assertThat(classUnderTest.inputStreamIndex()).isEqualTo(2);
+		assertThat(classUnderTest.language()).isEqualTo("und");
+		assertThat(classUnderTest.name()).isEqualTo("Subtitles");
+	}
+
+	@Test
+	void testRejectNegativeStreamIndex() {
+		assertThatIllegalArgumentException().isThrownBy(() -> new WebVttTrack(-1, "de", "DVB-TTML"));
+	}
+}

--- a/src/test/java/io/antmedia/test/statistic/StatsCollectorTest.java
+++ b/src/test/java/io/antmedia/test/statistic/StatsCollectorTest.java
@@ -651,10 +651,10 @@ public class StatsCollectorTest {
 
 	@Test
 	public void testCpuLimitOfHundredDisablesCpuAdmissionControl() {
-		StatsCollector monitor = Mockito.spy(new StatsCollector());
-		Mockito.when(monitor.getOSType()).thenReturn(SystemUtils.LINUX);
-		Mockito.when(monitor.getCpuLoad()).thenReturn(100);
-		Mockito.when(monitor.getMemoryLoad()).thenReturn(10);
+		StatsCollector monitor = spy(new StatsCollector());
+		when(monitor.getOSType()).thenReturn(SystemUtils.LINUX);
+		when(monitor.getCpuLoad()).thenReturn(100);
+		when(monitor.getMemoryLoad()).thenReturn(10);
 
 		monitor.setCpuLimit(100);
 		assertTrue(monitor.enoughResource());

--- a/src/test/java/io/antmedia/test/token/TokenFilterTest.java
+++ b/src/test/java/io/antmedia/test/token/TokenFilterTest.java
@@ -451,6 +451,10 @@ public class TokenFilterTest {
 		
 		assertEquals(streamId, TokenFilterManager.getStreamId("/liveapp/streams/"+streamId+ MuxAdaptor.ADAPTIVE_SUFFIX +".m3u8"));
 		assertEquals(streamId, TokenFilterManager.getStreamId("/liveapp/streams/subfolder/"+streamId+ MuxAdaptor.ADAPTIVE_SUFFIX +".m3u8"));
+		assertEquals(streamId, TokenFilterManager.getStreamId("/liveapp/streams/"+streamId+"_subtitles_6.m3u8"));
+		assertEquals(streamId, TokenFilterManager.getStreamId("/liveapp/streams/"+streamId+"_subtitles_6_60.vtt"));
+		assertEquals("stream_subtitles_name", TokenFilterManager.getStreamId(
+				"/liveapp/streams/subfolder/stream_subtitles_name_subtitles_12_345.vtt"));
 		
 		assertEquals("stream_Id_underline_test", TokenFilterManager.getStreamId("/liveapp/streams/"+streamId+ "_underline_test" +".m3u8"));
 		assertEquals("stream_Id_underline_test", TokenFilterManager.getStreamId("/liveapp/streams/subfolder/"+streamId+ "_underline_test" +".m3u8"));


### PR DESCRIPTION
## Summary

- expose DVB-TTML tracks as separate WebVTT subtitle renditions in HLS
- merge subtitle renditions into FFmpeg's multitrack-audio master playlist
- synchronize WebVTT media playlists with the video variant after FFmpeg creates or rewrites its manifests
- allow generated subtitle playlists and segments through token filtering
- resolve multitrack muxer Sonar findings

## Validation

- focused Community muxer/WebVTT tests
- Enterprise SRT and DVB-TTML tests
- CI unit tests, integration tests, and vulnerability checks